### PR TITLE
Add SSE heartbeat to prevent idle connection drops

### DIFF
--- a/hub/src/events.ts
+++ b/hub/src/events.ts
@@ -5,7 +5,26 @@ export type HubEvent =
   | { type: "join"; name: string; timestamp: number }
   | { type: "leave"; name: string; timestamp: number };
 
+const HEARTBEAT_INTERVAL_MS = 30_000; // 30 seconds
+
 const clients = new Set<ServerResponse>();
+let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+
+function startHeartbeat(): void {
+  if (heartbeatTimer) return;
+  heartbeatTimer = setInterval(() => {
+    for (const client of clients) {
+      client.write(":\n\n");
+    }
+  }, HEARTBEAT_INTERVAL_MS);
+}
+
+function stopHeartbeat(): void {
+  if (heartbeatTimer && clients.size === 0) {
+    clearInterval(heartbeatTimer);
+    heartbeatTimer = null;
+  }
+}
 
 export function addSSEClient(res: ServerResponse): void {
   res.writeHead(200, {
@@ -15,7 +34,11 @@ export function addSSEClient(res: ServerResponse): void {
   });
   res.write("\n");
   clients.add(res);
-  res.on("close", () => clients.delete(res));
+  startHeartbeat();
+  res.on("close", () => {
+    clients.delete(res);
+    stopHeartbeat();
+  });
 }
 
 export function broadcast(event: HubEvent): void {


### PR DESCRIPTION
## Summary

- Add 30-second heartbeat (SSE comment `:`) to the `/events` endpoint to keep connections alive during idle periods

## Details

The ON-AIR dashboard uses `EventSource` to receive real-time events. Without periodic traffic, the browser/OS silently closes the idle connection after ~15 minutes, causing the dashboard to stop updating.

The heartbeat timer starts when the first SSE client connects and stops when all clients disconnect.

Closes #3

## Test plan

- [x] Start the Hub and open the dashboard
- [x] Confirm heartbeat comments (`:`) appear every 30s in `curl -N http://localhost:9559/events`
- [x] Leave the dashboard idle for 15+ minutes, then send a message — verify it appears
- [x] Close all dashboard tabs and confirm the timer stops (no unnecessary work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)