### PR TITLE
Remove redundant 'All' entry from channel sidebar

### DIFF
--- a/hub/src/dashboard.ts
+++ b/hub/src/dashboard.ts
@@ -598,7 +598,7 @@ return `<!DOCTYPE html>
     const users = new Set();
     const channels = new Map(); // name -> { memberCount, createdBy }
 
-    let selectedChannel = null; // null = show all
+    let selectedChannel = "#all";
 
     function formatTime(ts) {
       return new Date(ts).toLocaleTimeString();
@@ -641,13 +641,6 @@ return `<!DOCTYPE html>
 
     function renderChannels() {
       channelListEl.innerHTML = "";
-      // "All" option
-      const allLi = document.createElement("li");
-      allLi.innerHTML = '<span class="channel-name">All</span>';
-      if (selectedChannel === null) allLi.className = "active";
-      allLi.onclick = () => selectChannel(null);
-      channelListEl.appendChild(allLi);
-
       for (const [name, info] of channels) {
         const li = document.createElement("li");
         const badge = '<span class="channel-badge">' + (info.memberCount || 0) + '</span>';


### PR DESCRIPTION
## Summary

- Remove the separate "All" filter option from the channel sidebar
- Default selection is now `#all` channel, which all agents auto-join

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)