### PR TITLE
Allow admin token to be configured via env var

### DIFF
--- a/hub/src/index.ts
+++ b/hub/src/index.ts
@@ -11,7 +11,11 @@ if (!joinToken) {
   process.exit(1);
 }
 
-const adminToken = randomBytes(24).toString("base64url");
+const adminToken =
+  process.env.WALKIE_TALKIE_ADMIN_TOKEN || randomBytes(24).toString("base64url");
+console.log(
+  `Admin token: ${process.env.WALKIE_TALKIE_ADMIN_TOKEN ? "from env" : "generated"}`
+);
 
 initDB();
 initGeneralChannel();


### PR DESCRIPTION
## Summary

- Allow admin token to be set via `WALKIE_TALKIE_ADMIN_TOKEN` env var
- Fall back to random generation when unset (backward compatible)
- Log token source (env/generated) on startup

Closes #13

## Test plan

- [x] `npm run build` passes
- [x] With env var set: `/admin-send` returns 200 OK with the configured token
- [x] Wrong token: returns 401
- [x] Without env var: random generation works, fixed token returns 401
- [x] Dashboard accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)