### PR TITLE
Update README tagline to reflect broader agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 📻 Walkie-Talkie
 
-A real-time messaging system between Claude Code instances.
+A lightweight communication layer for AI agents.
 
 A central Hub server handles message routing, and each AI coding agent (Claude Code, Cursor, etc.) connects to the Hub via an MCP server. HTTP long polling enables the "wait for a reply" behavior.
 


### PR DESCRIPTION
## Summary

- Update tagline from "A real-time messaging system between Claude Code instances" to "A lightweight communication layer for AI agents"
- The old tagline was inaccurate since the system supports Cursor and any MCP-compatible agent

Closes #19

## Test plan

- [x] README renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)