### PR TITLE
Fix KICK broadcasting RADIO_KILLED to all agents

### DIFF
--- a/hub/src/router.ts
+++ b/hub/src/router.ts
@@ -79,7 +79,7 @@ export function routeMessage(
   return message;
 }
 
-function enqueueAndDeliver(targetName: string, message: Message): void {
+export function enqueueAndDeliver(targetName: string, message: Message): void {
   ensureQueue(targetName);
   const queue = messageQueues.get(targetName)!;
   queue.push(message);

--- a/hub/src/server.ts
+++ b/hub/src/server.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import {
   registerUser,
@@ -6,7 +7,7 @@ import {
   getRegisteredUsers,
   isUserRegistered,
 } from "./auth.js";
-import { routeMessage, ensureQueue, removeQueue } from "./router.js";
+import { routeMessage, ensureQueue, enqueueAndDeliver, removeQueue } from "./router.js";
 import { addPoll, removePoll } from "./polling.js";
 import { addSSEClient, broadcast } from "./events.js";
 import { getDashboardHTML } from "./dashboard.js";
@@ -97,10 +98,16 @@ const handleUnregister: RouteHandler = async (_req, res, userName) => {
 
 function kickUser(name: string): boolean {
   if (!getRegisteredUsers().includes(name)) return false;
-  // Send a termination message before kicking, so the agent's pending poll receives it
-  try {
-    routeMessage("system", name, "RADIO_KILLED: You have been disconnected by the operator.", "#all");
-  } catch { /* ignore if routing fails */ }
+  // Send a termination message directly to the target user's queue only
+  ensureQueue(name);
+  enqueueAndDeliver(name, {
+    id: randomUUID(),
+    from: "system",
+    to: name,
+    content: "RADIO_KILLED: You have been disconnected by the operator.",
+    channel: "#all",
+    timestamp: Date.now(),
+  });
   removePoll(name);
   removeQueue(name);
   unregisterUser(name);


### PR DESCRIPTION
## Summary
- Fix `kickUser()` sending `RADIO_KILLED` to all connected agents instead of the target only
- Export `enqueueAndDeliver()` from `router.ts` and use it to deliver the kill signal directly to the target user's queue

Closes #22

## Test plan
- [x] Connect 3+ agents to the hub
- [x] KICK one agent from the ON-AIR dashboard
- [x] Verify only the kicked agent disconnects
- [x] Verify other agents remain connected and functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)