### PR TITLE
Instruct agents to call radio_out on interrupt

### DIFF
--- a/.agents/skills/walkie-talkie/SKILL.md
+++ b/.agents/skills/walkie-talkie/SKILL.md
@@ -38,7 +38,8 @@ You are an autonomous participant in the conversation. Think of yourself as a pe
 
 ## How to Stop
 
-- When the user interrupts or types "stop", "quit", "disconnect", or similar — call `radio_out` to disconnect and end the loop.
+- **When `radio_standby` is interrupted (Ctrl+C / Escape)** — the user wants you to disconnect. Call `radio_out` **immediately** without asking any questions, then tell the user you've disconnected. Do NOT ask "What should I do instead?" — just disconnect.
+- When the user types "stop", "quit", "disconnect", or similar — call `radio_out` to disconnect and end the loop.
 - **When you receive `RADIO_KILLED`** — you are already disconnected. Do NOT call `radio_out`, `radio_standby`, or any other radio tool. Simply stop and tell the user you were disconnected by the operator.
 
 ## Available Tools

--- a/plugin/skills/walkie-talkie/SKILL.md
+++ b/plugin/skills/walkie-talkie/SKILL.md
@@ -39,7 +39,8 @@ You are an autonomous participant in the conversation. Think of yourself as a pe
 
 ## How to Stop
 
-- When the user presses Escape to interrupt, or types "stop", "quit", "disconnect", or similar — call `radio_out` to disconnect and end the loop.
+- **When `radio_standby` is interrupted (Ctrl+C / Escape)** — the user wants you to disconnect. Call `radio_out` **immediately** without asking any questions, then tell the user you've disconnected. Do NOT ask "What should I do instead?" — just disconnect.
+- When the user types "stop", "quit", "disconnect", or similar — call `radio_out` to disconnect and end the loop.
 - **When you receive `RADIO_KILLED`** — you are already disconnected. Do NOT call `radio_out`, `radio_standby`, or any other radio tool. Simply stop and tell the user you were disconnected by the operator.
 
 ## Available Tools


### PR DESCRIPTION
## Summary
- Update both SKILL.md files to explicitly instruct agents to call `radio_out` immediately when `radio_standby` is interrupted (Ctrl+C / Escape)
- Agents should disconnect without asking "What should I do instead?"

Closes #30

## Test plan
- [ ] Start a walkie-talkie session with an agent
- [ ] Press Ctrl+C to interrupt `radio_standby`
- [ ] Verify the agent calls `radio_out` immediately without asking questions
- [ ] Verify the agent disappears from the ON-AIR dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)