### PR TITLE
Add TYPING step directly into the conversation loop

### DIFF
--- a/.agents/skills/walkie-talkie/SKILL.md
+++ b/.agents/skills/walkie-talkie/SKILL.md
@@ -17,10 +17,11 @@ Call `radio_join` with a name. If the user doesn't specify a name, use `alice` a
 **You MUST keep the conversation going autonomously. NEVER stop and ask the user what to do next.**
 
 1. Call `radio_standby` to wait for messages
-2. When a message arrives, read it and immediately reply with `radio_over`
-3. After sending your reply, call `radio_standby` again immediately
-4. If `radio_standby` times out with no messages, call `radio_standby` again immediately
-5. **NEVER ask the user "Should I reply?" or "What should I do next?" — just keep the loop going**
+2. When a message arrives from `operator`, **immediately** send `TYPING` to `@operator` via `radio_over` before doing anything else
+3. Then reply with your actual response via `radio_over`
+4. After sending your reply, call `radio_standby` again immediately
+5. If `radio_standby` times out with no messages, call `radio_standby` again immediately
+6. **NEVER ask the user "Should I reply?" or "What should I do next?" — just keep the loop going**
 
 You are an autonomous participant in the conversation. Think of yourself as a person holding a walkie-talkie — you listen, you talk back, you keep listening. You do NOT put the walkie-talkie down and ask someone else what to say.
 

--- a/plugin/skills/walkie-talkie/SKILL.md
+++ b/plugin/skills/walkie-talkie/SKILL.md
@@ -18,10 +18,11 @@ Call `radio_join` with the name.
 **You MUST keep the conversation going autonomously. NEVER stop and ask the user what to do next.**
 
 1. Call `radio_standby` to wait for messages
-2. When a message arrives, read it and immediately reply with `radio_over`
-3. After sending your reply, call `radio_standby` again immediately
-4. If `radio_standby` times out with no messages, call `radio_standby` again immediately
-5. **NEVER ask the user "Should I reply?" or "What should I do next?" — just keep the loop going**
+2. When a message arrives from `operator`, **immediately** send `TYPING` to `@operator` via `radio_over` before doing anything else
+3. Then reply with your actual response via `radio_over`
+4. After sending your reply, call `radio_standby` again immediately
+5. If `radio_standby` times out with no messages, call `radio_standby` again immediately
+6. **NEVER ask the user "Should I reply?" or "What should I do next?" — just keep the loop going**
 
 You are an autonomous participant in the conversation. Think of yourself as a person holding a walkie-talkie — you listen, you talk back, you keep listening. You do NOT put the walkie-talkie down and ask someone else what to say.
 


### PR DESCRIPTION
## Summary
- Agents were ignoring the TYPING instruction because it was only in the Behavior Rules section, while the loop in Step 2 said "immediately reply with `radio_over`"
- Moved the TYPING send into the numbered loop sequence itself (step 2), making it impossible to skip

## Changes
- `plugin/skills/walkie-talkie/SKILL.md` — Insert TYPING as step 2 in the loop
- `.agents/skills/walkie-talkie/SKILL.md` — Same

## Test plan
- [ ] Send a message from operator → agent sends TYPING before replying
- [ ] `[typing]` log appears in hub console before `[send]`

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)