### PR TITLE
Persist channel membership and auto-rejoin on reconnect

### DIFF
--- a/hub/src/channels.ts
+++ b/hub/src/channels.ts
@@ -1,4 +1,4 @@
-import { dbGetChannel } from "./db.js";
+import { dbGetChannel, dbAddChannelMember, dbRemoveChannelMember, dbRemoveAllMembersOfChannel } from "./db.js";
 
 const channelMembers = new Map<string, Set<string>>();
 
@@ -19,6 +19,7 @@ export function joinChannel(channel: string, userName: string): void {
     channelMembers.set(channel, members);
   }
   members.add(userName);
+  dbAddChannelMember(channel, userName);
 }
 
 export function leaveChannel(channel: string, userName: string): void {
@@ -26,6 +27,7 @@ export function leaveChannel(channel: string, userName: string): void {
   if (members) {
     members.delete(userName);
   }
+  dbRemoveChannelMember(channel, userName);
 }
 
 export function removeUserFromAllChannels(userName: string): void {
@@ -70,4 +72,5 @@ export function ensureChannelMembership(channel: string): void {
 
 export function removeChannel(channel: string): void {
   channelMembers.delete(channel);
+  dbRemoveAllMembersOfChannel(channel);
 }

--- a/hub/src/db.ts
+++ b/hub/src/db.ts
@@ -22,6 +22,14 @@ export function initDB(): void {
     )
   `);
 
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS channel_members (
+      channel TEXT NOT NULL,
+      user_name TEXT NOT NULL,
+      PRIMARY KEY (channel, user_name)
+    )
+  `);
+
   // Seed #all if it doesn't exist
   const existing = db.prepare("SELECT name FROM channels WHERE name = ?").get("#all");
   if (!existing) {
@@ -52,4 +60,21 @@ export function dbGetChannel(name: string): ChannelRow | undefined {
   return db.prepare("SELECT name, created_by, created_at FROM channels WHERE name = ?").get(name) as
     | ChannelRow
     | undefined;
+}
+
+export function dbAddChannelMember(channel: string, userName: string): void {
+  db.prepare("INSERT OR IGNORE INTO channel_members (channel, user_name) VALUES (?, ?)").run(channel, userName);
+}
+
+export function dbRemoveChannelMember(channel: string, userName: string): void {
+  db.prepare("DELETE FROM channel_members WHERE channel = ? AND user_name = ?").run(channel, userName);
+}
+
+export function dbRemoveAllMembersOfChannel(channel: string): void {
+  db.prepare("DELETE FROM channel_members WHERE channel = ?").run(channel);
+}
+
+export function dbGetUserChannels(userName: string): string[] {
+  const rows = db.prepare("SELECT channel FROM channel_members WHERE user_name = ?").all(userName) as { channel: string }[];
+  return rows.map((r) => r.channel);
 }

--- a/hub/src/server.ts
+++ b/hub/src/server.ts
@@ -12,7 +12,7 @@ import { routeMessage, ensureQueue, enqueueAndDeliver, removeQueue } from "./rou
 import { addPoll, removePoll, isOnline, setOnline, setOffline, onPollDisconnect } from "./polling.js";
 import { addSSEClient, broadcast } from "./events.js";
 import { getDashboardHTML } from "./dashboard.js";
-import { dbCreateChannel, dbDeleteChannel, dbGetChannel, dbListChannels } from "./db.js";
+import { dbCreateChannel, dbDeleteChannel, dbGetChannel, dbListChannels, dbGetUserChannels } from "./db.js";
 import {
   joinChannel,
   leaveChannel,
@@ -74,6 +74,16 @@ const handleRegister: RouteHandler = async (req, res) => {
     try {
       joinChannel("#all", body.name);
     } catch { /* already joined or channel issue */ }
+    // Restore previous channel memberships from DB
+    const previousChannels = dbGetUserChannels(body.name);
+    for (const ch of previousChannels) {
+      if (ch === "#all") continue;
+      try {
+        joinChannel(ch, body.name);
+        broadcast({ type: "channel_join", channel: ch, userName: body.name, timestamp: Date.now() });
+        console.log(`[auto-rejoin] ${body.name} -> ${ch}`);
+      } catch { /* channel may no longer exist */ }
+    }
     broadcast({ type: "join", name: body.name, timestamp: Date.now() });
     console.log(`[register] ${body.name}`);
     sendJson(res, 200, { token: user.token, name: user.name });


### PR DESCRIPTION
## Summary
- Add `channel_members` SQLite table to persist channel membership across server restarts
- Auto-rejoin previous channels on agent reconnect (explicit `/channel-leave` prevents rejoin)
- Clean up DB membership records when channels are deleted

## Test plan
- [x] `npm run build` passes
- [x] Agent joins `#room` → server restarts → agent reconnects → auto-rejoins `#room`
- [ ] Agent `/channel-leave #room` → server restarts → agent does NOT rejoin `#room`
- [ ] Channel deleted → no stale membership records in DB

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)