### PR TITLE
Persist channel messages in SQLite and restore on dashboard refresh

### DIFF
--- a/hub/src/dashboard.ts
+++ b/hub/src/dashboard.ts
@@ -1050,6 +1050,28 @@ return `<!DOCTYPE html>
       renderChannels();
     }).catch(() => {});
 
+    // Load message history from DB
+    fetch("/admin-channel-history", { headers: { "Authorization": "Bearer " + ADMIN_TOKEN } })
+      .then(r => r.json())
+      .then(data => {
+        if (data.messages && data.messages.length > 0) {
+          clearEmpty();
+          for (const msg of data.messages) {
+            const cls = msg.from === "operator" ? "message operator" : "message";
+            const channelTag = '<span class="channel-tag">' + (msg.channel || "#all") + '</span>';
+            addMessage(
+              '<span class="time">' + formatTime(msg.timestamp) + '</span>' +
+              channelTag +
+              '<span class="from">' + msg.from + '</span> ' +
+              '<span class="to">&rarr; ' + msg.to + '</span>' +
+              '<div class="content">' + msg.content.replace(/</g, "&lt;") + '</div>',
+              cls,
+              msg.channel || "#all"
+            );
+          }
+        }
+      }).catch(() => {});
+
     const es = new EventSource("/events");
 
     es.onmessage = (e) => {

--- a/hub/src/db.ts
+++ b/hub/src/db.ts
@@ -1,6 +1,8 @@
 import Database from "better-sqlite3";
 import path from "node:path";
 
+import type { Message } from "./types.js";
+
 export interface ChannelRow {
   name: string;
   created_by: string;
@@ -28,6 +30,22 @@ export function initDB(): void {
       user_name TEXT NOT NULL,
       PRIMARY KEY (channel, user_name)
     )
+  `);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS messages (
+      id TEXT PRIMARY KEY,
+      "from" TEXT NOT NULL,
+      "to" TEXT NOT NULL,
+      content TEXT NOT NULL,
+      channel TEXT NOT NULL,
+      timestamp INTEGER NOT NULL
+    )
+  `);
+
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_messages_channel_timestamp
+    ON messages (channel, timestamp)
   `);
 
   // Seed #all if it doesn't exist
@@ -77,4 +95,43 @@ export function dbRemoveAllMembersOfChannel(channel: string): void {
 export function dbGetUserChannels(userName: string): string[] {
   const rows = db.prepare("SELECT channel FROM channel_members WHERE user_name = ?").all(userName) as { channel: string }[];
   return rows.map((r) => r.channel);
+}
+
+const ALL_CHANNEL_MAX = 200;
+
+export function dbSaveMessage(msg: Message): void {
+  db.prepare(
+    `INSERT INTO messages (id, "from", "to", content, channel, timestamp) VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run(msg.id, msg.from, msg.to, msg.content, msg.channel, msg.timestamp);
+
+  if (msg.channel === "#all") {
+    dbPruneAllChannel();
+  }
+}
+
+export function dbGetChannelMessages(channel: string, limit = 50): Message[] {
+  return db.prepare(
+    `SELECT id, "from", "to", content, channel, timestamp FROM messages WHERE channel = ? ORDER BY timestamp ASC LIMIT ?`,
+  ).all(channel, limit) as Message[];
+}
+
+export function dbGetRecentMessages(limit = 200): Message[] {
+  return db.prepare(
+    `SELECT id, "from", "to", content, channel, timestamp FROM messages ORDER BY timestamp ASC LIMIT ?`,
+  ).all(limit) as Message[];
+}
+
+export function dbDeleteChannelMessages(channel: string): void {
+  db.prepare("DELETE FROM messages WHERE channel = ?").run(channel);
+}
+
+function dbPruneAllChannel(): void {
+  const count = (db.prepare("SELECT COUNT(*) as cnt FROM messages WHERE channel = '#all'").get() as { cnt: number }).cnt;
+  if (count > ALL_CHANNEL_MAX) {
+    db.prepare(
+      `DELETE FROM messages WHERE channel = '#all' AND id NOT IN (
+        SELECT id FROM messages WHERE channel = '#all' ORDER BY timestamp DESC LIMIT ?
+      )`,
+    ).run(ALL_CHANNEL_MAX);
+  }
 }

--- a/hub/src/router.ts
+++ b/hub/src/router.ts
@@ -3,6 +3,7 @@ import type { Message } from "./types.js";
 import { isUserRegistered } from "./auth.js";
 import { deliverMessage } from "./polling.js";
 import { getChannelMembers, isChannelMember } from "./channels.js";
+import { dbSaveMessage } from "./db.js";
 
 const messageQueues = new Map<string, Message[]>();
 
@@ -42,6 +43,8 @@ export function routeMessage(
       timestamp: Date.now(),
     };
 
+    dbSaveMessage(message);
+
     // Deliver to all channel members except sender
     for (const user of members) {
       if (user !== from) {
@@ -69,6 +72,8 @@ export function routeMessage(
     channel,
     timestamp: Date.now(),
   };
+
+  dbSaveMessage(message);
 
   // Deliver to all channel members except sender
   for (const user of members) {

--- a/hub/src/server.ts
+++ b/hub/src/server.ts
@@ -12,7 +12,7 @@ import { routeMessage, ensureQueue, enqueueAndDeliver, removeQueue } from "./rou
 import { addPoll, removePoll, isOnline, setOnline, setOffline, onPollDisconnect } from "./polling.js";
 import { addSSEClient, broadcast } from "./events.js";
 import { getDashboardHTML } from "./dashboard.js";
-import { dbCreateChannel, dbDeleteChannel, dbGetChannel, dbListChannels, dbGetUserChannels } from "./db.js";
+import { dbCreateChannel, dbDeleteChannel, dbGetChannel, dbListChannels, dbGetUserChannels, dbDeleteChannelMessages, dbGetChannelMessages, dbGetRecentMessages } from "./db.js";
 import {
   joinChannel,
   leaveChannel,
@@ -20,6 +20,7 @@ import {
   getChannelMemberCounts,
   ensureChannelMembership,
   removeChannel,
+  isChannelMember,
 } from "./channels.js";
 import type {
   RegisterRequest,
@@ -303,6 +304,20 @@ const handleListChannels: RouteHandler = async (_req, res) => {
   sendJson(res, 200, { channels: result });
 };
 
+const handleChannelHistory: RouteHandler = async (req, res, userName) => {
+  const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+  const channel = url.searchParams.get("channel");
+  if (!channel) {
+    return sendError(res, 400, "Missing 'channel' query parameter");
+  }
+  if (!isChannelMember(channel, userName!)) {
+    return sendError(res, 403, `You are not a member of ${channel}`);
+  }
+  const limit = Math.min(Math.max(parseInt(url.searchParams.get("limit") ?? "50", 10) || 50, 1), 200);
+  const messages = dbGetChannelMessages(channel, limit);
+  sendJson(res, 200, { messages });
+};
+
 const handleAdminChannelCreate: RouteHandler = async (req, res) => {
   const body = JSON.parse(await readBody(req)) as { name?: string };
   if (!body.name || typeof body.name !== "string") {
@@ -323,6 +338,19 @@ const handleAdminChannelCreate: RouteHandler = async (req, res) => {
   }
 };
 
+const handleAdminChannelHistory: RouteHandler = async (req, res) => {
+  const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+  const channel = url.searchParams.get("channel");
+  const limit = Math.min(Math.max(parseInt(url.searchParams.get("limit") ?? "200", 10) || 200, 1), 500);
+  if (channel) {
+    const messages = dbGetChannelMessages(channel, limit);
+    sendJson(res, 200, { messages });
+  } else {
+    const messages = dbGetRecentMessages(limit);
+    sendJson(res, 200, { messages });
+  }
+};
+
 const handleAdminChannelDelete: RouteHandler = async (req, res) => {
   const body = JSON.parse(await readBody(req)) as { name?: string };
   if (!body.name || typeof body.name !== "string") {
@@ -335,6 +363,7 @@ const handleAdminChannelDelete: RouteHandler = async (req, res) => {
     return sendError(res, 404, `Channel "${body.name}" not found`);
   }
   dbDeleteChannel(body.name);
+  dbDeleteChannelMessages(body.name);
   removeChannel(body.name);
   broadcast({ type: "channel_delete", name: body.name, timestamp: Date.now() });
   console.log(`[admin-channel-delete] ${body.name}`);
@@ -356,6 +385,7 @@ const adminRoutes: Record<string, { method: string; handler: RouteHandler }> = {
   "/admin-send": { method: "POST", handler: handleAdminSend },
   "/admin-channel-create": { method: "POST", handler: handleAdminChannelCreate },
   "/admin-channel-delete": { method: "POST", handler: handleAdminChannelDelete },
+  "/admin-channel-history": { method: "GET", handler: handleAdminChannelHistory },
 };
 
 const protectedRoutes: Record<string, { method: string; handler: RouteHandler }> = {
@@ -366,6 +396,7 @@ const protectedRoutes: Record<string, { method: string; handler: RouteHandler }>
   "/channel-join": { method: "POST", handler: handleChannelJoin },
   "/channel-leave": { method: "POST", handler: handleChannelLeave },
   "/channel-invite": { method: "POST", handler: handleChannelInvite },
+  "/channel-history": { method: "GET", handler: handleChannelHistory },
 };
 
 function authenticateBearer(req: IncomingMessage, expected: string): boolean {


### PR DESCRIPTION
## Summary

- Add `messages` SQLite table with `(channel, timestamp)` index for efficient queries
- Persist every routed message via `dbSaveMessage()` in `routeMessage()`
- Auto-prune `#all` channel to 200 messages on each insert
- Clean up messages when a channel is deleted
- Add `GET /channel-history` (user-authenticated) and `GET /admin-channel-history` (admin) endpoints
- Dashboard (ON-AIR page) fetches and renders message history on page refresh

## Test plan

- [x] `npm run build` passes
- [x] Messages persist across server restart
- [ ] `#all` never exceeds 200 messages in DB
- [ ] Channel deletion removes associated messages
- [ ] `/channel-history` returns correct history for channel members
- [ ] Dashboard refresh restores conversation log

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)