### PR TITLE
Rename Stop All to Kick all agents and exclude operator

### DIFF
--- a/hub/src/dashboard.ts
+++ b/hub/src/dashboard.ts
@@ -670,7 +670,7 @@ return `<!DOCTYPE html>
       <ul id="channel-list"></ul>
       <span class="sidebar-label">On Air</span>
       <ul id="user-list"></ul>
-      <button id="stop-all">Stop All</button>
+      <button id="stop-all">Kick all agents</button>
     </div>
     <div class="message-area">
       <div id="messages">

--- a/hub/src/server.ts
+++ b/hub/src/server.ts
@@ -176,11 +176,11 @@ const handleKick: RouteHandler = async (req, res) => {
 };
 
 const handleKickAll: RouteHandler = async (_req, res) => {
-  const allUsers = [...getRegisteredUsers()];
-  for (const name of allUsers) {
+  const agents = [...getRegisteredUsers()].filter(name => name !== "operator");
+  for (const name of agents) {
     kickUser(name);
   }
-  sendJson(res, 200, { ok: true, kicked: allUsers });
+  sendJson(res, 200, { ok: true, kicked: agents });
 };
 
 const handleAdminSend: RouteHandler = async (req, res) => {


### PR DESCRIPTION
## Summary
- Rename sidebar button from "Stop All" to "Kick all agents"
- Exclude operator from kick-all so only agents are disconnected

## Test plan
- [x] `npm run build` passes
- [x] Button shows "Kick all agents" label
- [ ] Clicking the button kicks all connected agents but not the operator

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)