### PR TITLE
Scope typing indicator to the active channel

### DIFF
--- a/hub/src/__tests__/api-messaging.test.ts
+++ b/hub/src/__tests__/api-messaging.test.ts
@@ -55,7 +55,7 @@ describe("POST /send", () => {
         "Content-Type": "application/json",
         Authorization: `Bearer ${token}`,
       },
-      body: JSON.stringify({ to: "@all", content: "TYPING" }),
+      body: JSON.stringify({ to: "@all", content: "TYPING", channel: "#general" }),
     });
     expect(res.status).toBe(200);
     const body = (await res.json()) as { id: string };

--- a/hub/src/dashboard.ts
+++ b/hub/src/dashboard.ts
@@ -698,7 +698,7 @@ export function getDashboardHTML(adminToken: string): string {
     const channelHeaderEl = document.getElementById("channel-header");
     const users = new Map(); // name -> online (boolean)
     const channels = new Map(); // name -> { memberCount, createdBy, members }
-    const typingUsers = new Map(); // name -> timeoutId
+    const typingUsers = new Map(); // name -> { timeoutId, channel }
     const pendingReply = new Map(); // name -> timeoutId (30s no-TYPING → grey)
 
     let selectedChannel = "#all";
@@ -727,7 +727,7 @@ export function getDashboardHTML(adminToken: string): string {
 
     const typingBarEl = document.getElementById("typing-bar");
     function renderTypingBar() {
-      const names = [...typingUsers.keys()];
+      const names = [...typingUsers.entries()].filter(([, v]) => v.channel === selectedChannel).map(([k]) => k);
       if (names.length === 0) {
         typingBarEl.className = "";
         typingBarEl.textContent = "";
@@ -744,7 +744,8 @@ export function getDashboardHTML(adminToken: string): string {
         const info = document.createElement("span");
         info.className = "user-info";
         const dotCls = online ? "user-dot" : "user-dot offline";
-        const typingHtml = typingUsers.has(u) ? '<span class="typing-indicator">typing...</span>' : '';
+        const tu = typingUsers.get(u);
+        const typingHtml = tu && tu.channel === selectedChannel ? '<span class="typing-indicator">typing...</span>' : '';
         info.innerHTML = '<span class="' + dotCls + '"></span><span class="user-name">' + u + '</span>' + typingHtml;
         const btn = document.createElement("button");
         btn.className = "kick-btn";
@@ -843,6 +844,8 @@ export function getDashboardHTML(adminToken: string): string {
       }
       markChannelRead(name);
       applyChannelFilter();
+      renderTypingBar();
+      renderUsers();
     }
 
     function applyChannelFilter() {
@@ -1171,7 +1174,7 @@ export function getDashboardHTML(adminToken: string): string {
         clearPendingReply(ev.from);
         if (users.has(ev.from)) users.set(ev.from, true);
         const existingTimer = typingUsers.get(ev.from);
-        if (existingTimer) { clearTimeout(existingTimer); typingUsers.delete(ev.from); renderUsers(); renderTypingBar(); }
+        if (existingTimer) { clearTimeout(existingTimer.timeoutId); typingUsers.delete(ev.from); renderUsers(); renderTypingBar(); }
         const cls = ev.from === "operator" ? "message operator" : "message";
         const channelTag = '<span class="channel-tag">' + (ev.channel || "#all") + '</span>';
         addMessage(
@@ -1234,8 +1237,8 @@ export function getDashboardHTML(adminToken: string): string {
         clearPendingReply(ev.name);
         if (users.has(ev.name)) users.set(ev.name, true);
         const prev = typingUsers.get(ev.name);
-        if (prev) clearTimeout(prev);
-        typingUsers.set(ev.name, setTimeout(() => { typingUsers.delete(ev.name); renderUsers(); renderTypingBar(); }, 60000));
+        if (prev) clearTimeout(prev.timeoutId);
+        typingUsers.set(ev.name, { timeoutId: setTimeout(() => { typingUsers.delete(ev.name); renderUsers(); renderTypingBar(); }, 60000), channel: ev.channel || "#all" });
         renderUsers();
         renderTypingBar();
       }

--- a/hub/src/events.ts
+++ b/hub/src/events.ts
@@ -9,7 +9,7 @@ export type HubEvent =
   | { type: "channel_leave"; channel: string; userName: string; timestamp: number }
   | { type: "channel_delete"; name: string; timestamp: number }
   | { type: "status"; name: string; online: boolean; timestamp: number }
-  | { type: "typing"; name: string; timestamp: number }
+  | { type: "typing"; name: string; channel: string; timestamp: number }
   | { type: "read_update"; userName: string; channel: string; timestamp: number };
 
 const HEARTBEAT_INTERVAL_MS = 30_000; // 30 seconds

--- a/hub/src/server.ts
+++ b/hub/src/server.ts
@@ -114,7 +114,7 @@ const handleSend: RouteHandler = async (req, res, userName) => {
   if (body.content === "TYPING") {
     const channel = body.channel || "#all";
     dbUpdateReadCursor(userName!, channel);
-    broadcast({ type: "typing", name: userName!, timestamp: Date.now() });
+    broadcast({ type: "typing", name: userName!, channel, timestamp: Date.now() });
     console.log(`[typing] ${userName}`);
     return sendJson(res, 200, { id: "typing", to: body.to });
   }


### PR DESCRIPTION
## Summary
- Add `channel` field to the `typing` event type and server broadcast
- Filter typing indicators in the dashboard by `selectedChannel` so they only appear in the relevant channel
- Re-render typing bar and user list on channel switch to clear stale indicators
- Update TYPING test to include channel parameter

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 81 tests pass
- [x] `npx biome ci hub/src/` — clean
- [x] Manual: trigger typing in `#alice-room`, verify it does NOT show in `#all`
- [x] Manual: switch channels while typing indicator is active, verify it disappears

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)