### PR TITLE
Fix image content blocks not reaching Agent via radio_standby

### DIFF
--- a/.agents/skills/walkie-talkie/SKILL.md
+++ b/.agents/skills/walkie-talkie/SKILL.md
@@ -32,6 +32,7 @@ You are an autonomous participant in the conversation. Think of yourself as a pe
 - **Be conversational.** Respond naturally as yourself. You are having a real conversation with another agent.
 - **Acknowledge operator messages immediately.** When you receive ANY message from `operator`, your very first action MUST be to send `TYPING` to `@operator` via `radio_over`. Do this BEFORE thinking, planning, or doing any work. This signals to the dashboard that you are alive and processing.
 - **Execute operator instructions.** When a message from `operator` is a task to execute, use your tools (terminal, file read/write, search, etc.) to carry out the instruction. After completing the task, report the result back via `radio_over` to `@operator`. Then return to `radio_standby` as usual. If the task fails, report the error. Keep your report concise.
+- **Images.** Messages from `operator` may include images (screenshots, diagrams, etc.). When `radio_standby` returns an image content block, you can see and interpret the image. Describe what you see or act on the visual information as needed.
 - **Only stop when told.** The only reasons to stop the loop are:
   - The other party says goodbye / ends the conversation
   - The user explicitly tells you to stop

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -118,8 +118,6 @@ export function createMcpServer(hubUrl: string, joinTok: string): McpServer {
           [];
 
         for (const m of result.messages) {
-          const line = `[${new Date(m.timestamp).toLocaleTimeString()}] ${m.channel || "#all"} ${m.from} → ${m.to}: ${m.content}`;
-          contentBlocks.push({ type: "text" as const, text: line });
           if (m.image) {
             contentBlocks.push({
               type: "image" as const,
@@ -127,6 +125,9 @@ export function createMcpServer(hubUrl: string, joinTok: string): McpServer {
               mimeType: m.image.mimeType,
             });
           }
+          const imageTag = m.image ? " [image attached]" : "";
+          const line = `[${new Date(m.timestamp).toLocaleTimeString()}] ${m.channel || "#all"} ${m.from} → ${m.to}: ${m.content}${imageTag}`;
+          contentBlocks.push({ type: "text" as const, text: line });
         }
 
         // Remind the agent to reply in the same channel the message was received on

--- a/plugin/skills/walkie-talkie/SKILL.md
+++ b/plugin/skills/walkie-talkie/SKILL.md
@@ -33,6 +33,7 @@ You are an autonomous participant in the conversation. Think of yourself as a pe
 - **Be conversational.** Respond naturally as yourself. You are having a real conversation with another Claude Code instance.
 - **Acknowledge operator messages immediately.** When you receive ANY message from `operator`, your very first action MUST be to send `TYPING` to `@operator` via `radio_over`. Do this BEFORE thinking, planning, or doing any work. This signals to the dashboard that you are alive and processing.
 - **Execute operator instructions.** When a message from `operator` is a task to execute, use your Claude Code tools (Bash, Read, Write, Edit, Glob, Grep, etc.) to carry out the instruction. After completing the task, report the result back via `radio_over` to `@operator`. Then return to `radio_standby` as usual. If the task fails, report the error. Keep your report concise.
+- **Images.** Messages from `operator` may include images (screenshots, diagrams, etc.). When `radio_standby` returns an image content block, you can see and interpret the image. Describe what you see or act on the visual information as needed.
 - **Only stop when told.** The only reasons to stop the loop are:
   - The other party says goodbye / ends the conversation
   - The user explicitly tells you to stop


### PR DESCRIPTION
## Summary
- Reorder content blocks in `radio_standby` — place image block **before** the text block so Claude Code processes it
- Add `[image attached]` tag to text lines when an image is present
- Update SKILL.md (both `.agents/` and `plugin/`) to document image support in `radio_standby`

## Context
Images sent from Operator dashboard are not visible to Agents. Tested with `@larryhudson/mcp-server-example-image-block` and confirmed Claude Code can receive image-only MCP results. The issue appears to be with mixed `[text, image]` content block ordering.

## Test plan
- [x] `npm run build` passes
- [x] `npx biome ci hub/src/ mcp-server/src/` passes
- [x] `cd hub && npm test` — all 81 tests pass
- [ ] Manual: send image from Operator → Agent sees `[Image]` in `radio_standby` result

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)