### PR TITLE
Support image sending from Agent to Operator via radio_over

### DIFF
--- a/hub/src/server.ts
+++ b/hub/src/server.ts
@@ -107,7 +107,7 @@ const handleRegister: RouteHandler = async (req, res) => {
 
 const handleSend: RouteHandler = async (req, res, userName) => {
   const body = JSON.parse(await readBody(req)) as SendRequest;
-  if (!body.to || !body.content) {
+  if (!body.to || (!body.content && !body.image)) {
     return sendError(res, 400, "Missing 'to' or 'content' field");
   }
   // Typing indicator: broadcast typing event without routing to chat log
@@ -118,9 +118,10 @@ const handleSend: RouteHandler = async (req, res, userName) => {
     console.log(`[typing] ${userName}`);
     return sendJson(res, 200, { id: "typing", to: body.to });
   }
+  const content = body.content || "";
   const channel = body.channel || "#all";
   try {
-    const message = routeMessage(userName!, body.to, body.content, channel);
+    const message = routeMessage(userName!, body.to, content, channel, body.image);
     broadcast({
       type: "message",
       from: message.from,
@@ -128,8 +129,9 @@ const handleSend: RouteHandler = async (req, res, userName) => {
       content: message.content,
       channel: message.channel,
       timestamp: message.timestamp,
+      image: message.image,
     });
-    console.log(`[send] ${userName} -> ${body.to} (${channel}): ${body.content}`);
+    console.log(`[send] ${userName} -> ${body.to} (${channel}): ${content}${body.image ? " [+image]" : ""}`);
     sendJson(res, 200, { id: message.id, to: message.to });
   } catch (e) {
     sendError(res, 404, (e as Error).message);

--- a/mcp-server/src/client.ts
+++ b/mcp-server/src/client.ts
@@ -100,9 +100,19 @@ export class HubClient {
     });
   }
 
-  async send(token: string, to: string, content: string, channel?: string): Promise<{ id: string; to: string }> {
-    const body: { to: string; content: string; channel?: string } = { to, content };
+  async send(
+    token: string,
+    to: string,
+    content: string,
+    channel?: string,
+    image?: { data: string; mimeType: string },
+  ): Promise<{ id: string; to: string }> {
+    const body: { to: string; content: string; channel?: string; image?: { data: string; mimeType: string } } = {
+      to,
+      content,
+    };
     if (channel) body.channel = channel;
+    if (image) body.image = image;
     const res = await this.request<{ id: string; to: string }>({
       method: "POST",
       path: "/send",

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -54,8 +54,16 @@ export function createMcpServer(hubUrl: string, joinTok: string): McpServer {
         .describe(
           "Channel to send to. IMPORTANT: Always reply in the same channel where you received the message. Defaults to #all if omitted.",
         ),
+      image_data: z
+        .string()
+        .optional()
+        .describe("Base64-encoded image data. Must be provided together with image_mime_type."),
+      image_mime_type: z
+        .string()
+        .optional()
+        .describe("MIME type of the image (e.g. 'image/png'). Must be provided together with image_data."),
     },
-    async ({ to, message, channel }) => {
+    async ({ to, message, channel, image_data, image_mime_type }) => {
       if (!currentToken) {
         return {
           content: [{ type: "text" as const, text: "Not on the air. Use radio_join first." }],
@@ -63,7 +71,8 @@ export function createMcpServer(hubUrl: string, joinTok: string): McpServer {
         };
       }
       try {
-        const result = await client.send(currentToken, to, message, channel);
+        const image = image_data && image_mime_type ? { data: image_data, mimeType: image_mime_type } : undefined;
+        const result = await client.send(currentToken, to, message, channel, image);
         return {
           content: [
             {

--- a/plugin/dist/mcp-server.mjs
+++ b/plugin/dist/mcp-server.mjs
@@ -30168,9 +30168,13 @@ var HubClient = class {
       token
     });
   }
-  async send(token, to, content, channel) {
-    const body = { to, content };
+  async send(token, to, content, channel, image) {
+    const body = {
+      to,
+      content
+    };
     if (channel) body.channel = channel;
+    if (image) body.image = image;
     const res = await this.request({
       method: "POST",
       path: "/send",
@@ -30310,9 +30314,11 @@ function createMcpServer(hubUrl2, joinTok) {
       message: external_exports.string().describe("Message content"),
       channel: external_exports.string().optional().describe(
         "Channel to send to. IMPORTANT: Always reply in the same channel where you received the message. Defaults to #all if omitted."
-      )
+      ),
+      image_data: external_exports.string().optional().describe("Base64-encoded image data. Must be provided together with image_mime_type."),
+      image_mime_type: external_exports.string().optional().describe("MIME type of the image (e.g. 'image/png'). Must be provided together with image_data.")
     },
-    async ({ to, message, channel }) => {
+    async ({ to, message, channel, image_data, image_mime_type }) => {
       if (!currentToken) {
         return {
           content: [{ type: "text", text: "Not on the air. Use radio_join first." }],
@@ -30320,7 +30326,8 @@ function createMcpServer(hubUrl2, joinTok) {
         };
       }
       try {
-        const result = await client.send(currentToken, to, message, channel);
+        const image = image_data && image_mime_type ? { data: image_data, mimeType: image_mime_type } : void 0;
+        const result = await client.send(currentToken, to, message, channel, image);
         return {
           content: [
             {


### PR DESCRIPTION
## Summary
- Enable Agent → Operator image sending via `radio_over` tool
- Update `/send` endpoint to accept and forward `image` field (mirroring `/admin-send` behavior)
- Add `image` parameter to `HubClient.send()` method
- Add `image_data` and `image_mime_type` optional params to `radio_over` MCP tool
- Rebuild plugin bundle to include changes

## Test plan
- [x] `npm run build` passes
- [x] `npx biome ci hub/src/ mcp-server/src/` passes
- [x] `cd hub && npm test` passes (81 tests)
- [x] `npm run bundle` regenerates plugin dist
- [ ] Manual test: Agent sends `radio_over` with `image_data` + `image_mime_type` → Operator dashboard displays the image

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)