### PR TITLE
Add radio_send_image tool for fast file-based image sending

### DIFF
--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -1,6 +1,45 @@
+import fs from "node:fs";
+import http from "node:http";
+import https from "node:https";
+import path from "node:path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { HubClient } from "./client.js";
+
+const MIME_TYPES: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+};
+
+function getMimeType(source: string): string {
+  const ext = path.extname(source).toLowerCase();
+  return MIME_TYPES[ext] ?? "image/png";
+}
+
+function fetchUrl(url: string): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const transport = url.startsWith("https") ? https : http;
+    transport
+      .get(url, (res) => {
+        if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+          fetchUrl(res.headers.location).then(resolve, reject);
+          return;
+        }
+        if (res.statusCode && res.statusCode >= 400) {
+          reject(new Error(`HTTP ${res.statusCode}`));
+          return;
+        }
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => resolve(Buffer.concat(chunks)));
+        res.on("error", reject);
+      })
+      .on("error", reject);
+  });
+}
 
 let client: HubClient;
 let joinToken: string;
@@ -84,6 +123,49 @@ export function createMcpServer(hubUrl: string, joinTok: string): McpServer {
       } catch (e) {
         return {
           content: [{ type: "text" as const, text: `Send failed: ${(e as Error).message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
+    "radio_send_image",
+    "Send an image from a local file path or URL. Much faster than passing base64 via radio_over.",
+    {
+      to: z.string().describe("Recipient: @name or @all"),
+      source: z.string().describe("Image file path or URL (http/https)"),
+      message: z.string().optional().describe("Optional text message to accompany the image"),
+      channel: z.string().optional().describe("Channel to send to (default: #all)"),
+    },
+    async ({ to, source, message, channel }) => {
+      if (!currentToken) {
+        return {
+          content: [{ type: "text" as const, text: "Not on the air. Use radio_join first." }],
+          isError: true,
+        };
+      }
+      try {
+        let buf: Buffer;
+        if (source.startsWith("http://") || source.startsWith("https://")) {
+          buf = await fetchUrl(source);
+        } else {
+          buf = fs.readFileSync(source);
+        }
+        const data = buf.toString("base64");
+        const mimeType = getMimeType(source);
+        const result = await client.send(currentToken, to, message ?? "", channel, { data, mimeType });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Image sent to ${result.to} in ${channel || "#all"} (id: ${result.id})`,
+            },
+          ],
+        };
+      } catch (e) {
+        return {
+          content: [{ type: "text" as const, text: `Failed to send image: ${(e as Error).message}` }],
           isError: true,
         };
       }

--- a/plugin/dist/mcp-server.mjs
+++ b/plugin/dist/mcp-server.mjs
@@ -3222,8 +3222,8 @@ var require_utils = __commonJS({
       }
       return ind;
     }
-    function removeDotSegments(path) {
-      let input = path;
+    function removeDotSegments(path2) {
+      let input = path2;
       const output = [];
       let nextSlash = -1;
       let len = 0;
@@ -3422,8 +3422,8 @@ var require_schemes = __commonJS({
         wsComponent.secure = void 0;
       }
       if (wsComponent.resourceName) {
-        const [path, query] = wsComponent.resourceName.split("?");
-        wsComponent.path = path && path !== "/" ? path : void 0;
+        const [path2, query] = wsComponent.resourceName.split("?");
+        wsComponent.path = path2 && path2 !== "/" ? path2 : void 0;
         wsComponent.query = query;
         wsComponent.resourceName = void 0;
       }
@@ -3482,7 +3482,7 @@ var require_schemes = __commonJS({
       urnComponent.nss = (uuidComponent.uuid || "").toLowerCase();
       return urnComponent;
     }
-    var http2 = (
+    var http3 = (
       /** @type {SchemeHandler} */
       {
         scheme: "http",
@@ -3491,11 +3491,11 @@ var require_schemes = __commonJS({
         serialize: httpSerialize
       }
     );
-    var https2 = (
+    var https3 = (
       /** @type {SchemeHandler} */
       {
         scheme: "https",
-        domainHost: http2.domainHost,
+        domainHost: http3.domainHost,
         parse: httpParse,
         serialize: httpSerialize
       }
@@ -3539,8 +3539,8 @@ var require_schemes = __commonJS({
     var SCHEMES = (
       /** @type {Record<SchemeName, SchemeHandler>} */
       {
-        http: http2,
-        https: https2,
+        http: http3,
+        https: https3,
         ws,
         wss,
         urn,
@@ -6785,12 +6785,12 @@ var require_dist = __commonJS({
         throw new Error(`Unknown format "${name}"`);
       return f;
     };
-    function addFormats(ajv, list, fs, exportName) {
+    function addFormats(ajv, list, fs2, exportName) {
       var _a2;
       var _b;
       (_a2 = (_b = ajv.opts.code).formats) !== null && _a2 !== void 0 ? _a2 : _b.formats = (0, codegen_1._)`require("ajv-formats/dist/formats").${exportName}`;
       for (const f of list)
-        ajv.addFormat(f, fs[f]);
+        ajv.addFormat(f, fs2[f]);
     }
     module.exports = exports = formatsPlugin;
     Object.defineProperty(exports, "__esModule", { value: true });
@@ -7568,10 +7568,10 @@ function mergeDefs(...defs) {
 function cloneDef(schema) {
   return mergeDefs(schema._zod.def);
 }
-function getElementAtPath(obj, path) {
-  if (!path)
+function getElementAtPath(obj, path2) {
+  if (!path2)
     return obj;
-  return path.reduce((acc, key) => acc?.[key], obj);
+  return path2.reduce((acc, key) => acc?.[key], obj);
 }
 function promiseAllObject(promisesObj) {
   const keys = Object.keys(promisesObj);
@@ -7954,11 +7954,11 @@ function aborted(x, startIndex = 0) {
   }
   return false;
 }
-function prefixIssues(path, issues) {
+function prefixIssues(path2, issues) {
   return issues.map((iss) => {
     var _a2;
     (_a2 = iss).path ?? (_a2.path = []);
-    iss.path.unshift(path);
+    iss.path.unshift(path2);
     return iss;
   });
 }
@@ -8141,7 +8141,7 @@ function formatError(error48, mapper = (issue2) => issue2.message) {
 }
 function treeifyError(error48, mapper = (issue2) => issue2.message) {
   const result = { errors: [] };
-  const processError = (error49, path = []) => {
+  const processError = (error49, path2 = []) => {
     var _a2, _b;
     for (const issue2 of error49.issues) {
       if (issue2.code === "invalid_union" && issue2.errors.length) {
@@ -8151,7 +8151,7 @@ function treeifyError(error48, mapper = (issue2) => issue2.message) {
       } else if (issue2.code === "invalid_element") {
         processError({ issues: issue2.issues }, issue2.path);
       } else {
-        const fullpath = [...path, ...issue2.path];
+        const fullpath = [...path2, ...issue2.path];
         if (fullpath.length === 0) {
           result.errors.push(mapper(issue2));
           continue;
@@ -8183,8 +8183,8 @@ function treeifyError(error48, mapper = (issue2) => issue2.message) {
 }
 function toDotPath(_path) {
   const segs = [];
-  const path = _path.map((seg) => typeof seg === "object" ? seg.key : seg);
-  for (const seg of path) {
+  const path2 = _path.map((seg) => typeof seg === "object" ? seg.key : seg);
+  for (const seg of path2) {
     if (typeof seg === "number")
       segs.push(`[${seg}]`);
     else if (typeof seg === "symbol")
@@ -20161,13 +20161,13 @@ function resolveRef(ref, ctx) {
   if (!ref.startsWith("#")) {
     throw new Error("External $ref is not supported, only local refs (#/...) are allowed");
   }
-  const path = ref.slice(1).split("/").filter(Boolean);
-  if (path.length === 0) {
+  const path2 = ref.slice(1).split("/").filter(Boolean);
+  if (path2.length === 0) {
     return ctx.rootSchema;
   }
   const defsKey = ctx.version === "draft-2020-12" ? "$defs" : "definitions";
-  if (path[0] === defsKey) {
-    const key = path[1];
+  if (path2[0] === defsKey) {
+    const key = path2[1];
     if (!key || !ctx.defs[key]) {
       throw new Error(`Reference not found: ${ref}`);
     }
@@ -22176,6 +22176,12 @@ var StdioServerTransport = class {
   }
 };
 
+// mcp-server/src/tools.ts
+import fs from "node:fs";
+import http2 from "node:http";
+import https2 from "node:https";
+import path from "node:path";
+
 // node_modules/zod/v3/helpers/util.js
 var util;
 (function(util2) {
@@ -22535,8 +22541,8 @@ function getErrorMap2() {
 
 // node_modules/zod/v3/helpers/parseUtil.js
 var makeIssue = (params) => {
-  const { data, path, errorMaps, issueData } = params;
-  const fullPath = [...path, ...issueData.path || []];
+  const { data, path: path2, errorMaps, issueData } = params;
+  const fullPath = [...path2, ...issueData.path || []];
   const fullIssue = {
     ...issueData,
     path: fullPath
@@ -22651,11 +22657,11 @@ var errorUtil;
 
 // node_modules/zod/v3/types.js
 var ParseInputLazyPath = class {
-  constructor(parent, value, path, key) {
+  constructor(parent, value, path2, key) {
     this._cachedPath = [];
     this.parent = parent;
     this.data = value;
-    this._path = path;
+    this._path = path2;
     this._key = key;
   }
   get path() {
@@ -30270,6 +30276,36 @@ var HubClient = class {
 };
 
 // mcp-server/src/tools.ts
+var MIME_TYPES = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp"
+};
+function getMimeType(source) {
+  const ext = path.extname(source).toLowerCase();
+  return MIME_TYPES[ext] ?? "image/png";
+}
+function fetchUrl(url2) {
+  return new Promise((resolve, reject) => {
+    const transport2 = url2.startsWith("https") ? https2 : http2;
+    transport2.get(url2, (res) => {
+      if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+        fetchUrl(res.headers.location).then(resolve, reject);
+        return;
+      }
+      if (res.statusCode && res.statusCode >= 400) {
+        reject(new Error(`HTTP ${res.statusCode}`));
+        return;
+      }
+      const chunks = [];
+      res.on("data", (chunk) => chunks.push(chunk));
+      res.on("end", () => resolve(Buffer.concat(chunks)));
+      res.on("error", reject);
+    }).on("error", reject);
+  });
+}
 var client;
 var joinToken;
 var currentToken = null;
@@ -30339,6 +30375,48 @@ function createMcpServer(hubUrl2, joinTok) {
       } catch (e) {
         return {
           content: [{ type: "text", text: `Send failed: ${e.message}` }],
+          isError: true
+        };
+      }
+    }
+  );
+  server2.tool(
+    "radio_send_image",
+    "Send an image from a local file path or URL. Much faster than passing base64 via radio_over.",
+    {
+      to: external_exports.string().describe("Recipient: @name or @all"),
+      source: external_exports.string().describe("Image file path or URL (http/https)"),
+      message: external_exports.string().optional().describe("Optional text message to accompany the image"),
+      channel: external_exports.string().optional().describe("Channel to send to (default: #all)")
+    },
+    async ({ to, source, message, channel }) => {
+      if (!currentToken) {
+        return {
+          content: [{ type: "text", text: "Not on the air. Use radio_join first." }],
+          isError: true
+        };
+      }
+      try {
+        let buf;
+        if (source.startsWith("http://") || source.startsWith("https://")) {
+          buf = await fetchUrl(source);
+        } else {
+          buf = fs.readFileSync(source);
+        }
+        const data = buf.toString("base64");
+        const mimeType = getMimeType(source);
+        const result = await client.send(currentToken, to, message ?? "", channel, { data, mimeType });
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Image sent to ${result.to} in ${channel || "#all"} (id: ${result.id})`
+            }
+          ]
+        };
+      } catch (e) {
+        return {
+          content: [{ type: "text", text: `Failed to send image: ${e.message}` }],
           isError: true
         };
       }


### PR DESCRIPTION
## Summary
- Add `radio_send_image` MCP tool that reads image files (local path or URL) server-side and sends via existing image pipeline
- Eliminates the need for LLMs to output slow base64 tokens through `radio_over`
- Supports png, jpg, jpeg, gif, webp with automatic MIME type detection
- Includes redirect-following for URL sources

## Test plan
- [x] `npm run build` passes
- [x] `npx biome ci hub/src/ mcp-server/src/` passes
- [x] `cd hub && npm test` — 81/81 tests pass
- [x] `npm run bundle` regenerates plugin bundle
- [ ] Manual test: Agent sends `radio_send_image(to: "@all", source: "/tmp/test.png")` → image appears on dashboard

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)