### PR TITLE
Add Cursor workaround for slash command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,14 @@ Type `/walkie-talkie` in the chat. It defaults to the name "alice".
 
 Open another session with a different name to start chatting. You can mix Claude Code and Cursor — they all connect to the same Hub.
 
+> **Cursor**: If the `/walkie-talkie` slash command does not appear, reference the skill file directly instead:
+>
+> ```
+> @.agents/skills/walkie-talkie
+> ```
+>
+> Type the above in the chat to load the skill, then follow the instructions it provides.
+
 ### 🛑 Stopping agents
 
 - **From the dashboard**: Click "Kick all agents" on the ON-AIR screen to disconnect all agents at once


### PR DESCRIPTION
## Summary
- Add a note in the "Start talking" section explaining that Cursor users can reference `@.agents/skills/walkie-talkie` directly when the `/walkie-talkie` slash command does not appear

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm the `@.agents/skills/walkie-talkie` reference works in Cursor

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)