### PR TITLE
Bump version to v1.4.0

### DIFF
--- a/hub/package.json
+++ b/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@walkie-talkie/hub",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@walkie-talkie/mcp-server",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "walkie-talkie",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/slack-bot/package.json
+++ b/slack-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@walkie-talkie/slack-bot",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bump version to v1.4.0 across all workspaces (root, hub, mcp-server, slack-bot)

## Changelog since v1.3.0
- Add Slack bot integration via Socket Mode (#72)
- Add Cursor workaround for slash command in README (#70)

🤖 Generated with [Claude Code](https://claude.com/claude-code)