### PR TITLE
Add tests for image sending feature

### DIFF
--- a/hub/src/__tests__/api-admin.test.ts
+++ b/hub/src/__tests__/api-admin.test.ts
@@ -85,6 +85,35 @@ describe("POST /admin-send", () => {
     expect(body.to).toBe("@all");
   });
 
+  it("should send a message with image as operator", async () => {
+    await registerUser(ctx, "admin-img-recv");
+    const res = await fetch(`${ctx.baseUrl}/admin-send`, {
+      method: "POST",
+      headers: adminHeaders(),
+      body: JSON.stringify({
+        to: "@all",
+        content: "see this",
+        image: { data: "iVBORw0KGgo=", mimeType: "image/png" },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { id: string; to: string };
+    expect(body.id).toBeTruthy();
+  });
+
+  it("should accept image-only admin message", async () => {
+    await registerUser(ctx, "admin-imgonly-recv");
+    const res = await fetch(`${ctx.baseUrl}/admin-send`, {
+      method: "POST",
+      headers: adminHeaders(),
+      body: JSON.stringify({
+        to: "@all",
+        image: { data: "iVBORw0KGgo=", mimeType: "image/png" },
+      }),
+    });
+    expect(res.status).toBe(200);
+  });
+
   it("should reject missing fields", async () => {
     const res = await fetch(`${ctx.baseUrl}/admin-send`, {
       method: "POST",

--- a/hub/src/__tests__/api-messaging.test.ts
+++ b/hub/src/__tests__/api-messaging.test.ts
@@ -88,6 +88,45 @@ describe("POST /send", () => {
     expect(res.status).toBe(404);
   });
 
+  it("should send a message with image", async () => {
+    const token = await registerUser(ctx, "img-sender");
+    await registerUser(ctx, "img-receiver");
+
+    const res = await fetch(`${ctx.baseUrl}/send`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        to: "@all",
+        content: "check this image",
+        image: { data: "iVBORw0KGgo=", mimeType: "image/png" },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { id: string; to: string };
+    expect(body.id).toBeTruthy();
+  });
+
+  it("should accept image-only message without content", async () => {
+    const token = await registerUser(ctx, "imgonly-sender");
+    await registerUser(ctx, "imgonly-receiver");
+
+    const res = await fetch(`${ctx.baseUrl}/send`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        to: "@all",
+        image: { data: "iVBORw0KGgo=", mimeType: "image/png" },
+      }),
+    });
+    expect(res.status).toBe(200);
+  });
+
   it("should reject unauthorized send", async () => {
     const res = await fetch(`${ctx.baseUrl}/send`, {
       method: "POST",

--- a/hub/src/__tests__/router.test.ts
+++ b/hub/src/__tests__/router.test.ts
@@ -103,4 +103,21 @@ describe("routeMessage", () => {
     expect(bobMsgs).toHaveLength(1);
     expect(bobMsgs[0].channel).toBe("#room");
   });
+
+  it("should include image in routed message", () => {
+    registerUser("alice");
+    registerUser("bob");
+    ensureQueue("alice");
+    ensureQueue("bob");
+    joinChannel("#all", "alice");
+    joinChannel("#all", "bob");
+
+    const image = { data: "iVBORw0KGgo=", mimeType: "image/png" };
+    const msg = routeMessage("alice", "@all", "check this", "#all", image);
+    expect(msg.image).toEqual(image);
+
+    const bobMsgs = drainQueue("bob");
+    expect(bobMsgs).toHaveLength(1);
+    expect(bobMsgs[0].image).toEqual(image);
+  });
 });


### PR DESCRIPTION
## Summary
- Add image routing test in `router.test.ts` (image preserved in message and recipient queue)
- Add image message tests in `api-messaging.test.ts` (with content + image-only)
- Add admin image message tests in `api-admin.test.ts` (with content + image-only)
- Test count: 81 → 86

## Test plan
- [x] `npm test` — all 86 tests pass

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)