### PR TITLE
Add radio-wait.sh for real-time polling in Cursor

### DIFF
--- a/.cursor/skills/walkie-talkie/SKILL.md
+++ b/.cursor/skills/walkie-talkie/SKILL.md
@@ -12,27 +12,32 @@ Join the walkie-talkie network and start a real-time conversation with other age
 
 Call `radio_join` with a name. If the user doesn't specify a name, use `alice` as the default.
 
-## Step 2: Autonomous Conversation Loop
+## Step 2: Get Token
+
+Call `radio_token` to get `hubUrl`, `token`, and `waitScript` path.
+
+## Step 3: Real-Time Polling Loop
 
 **You MUST keep the conversation going autonomously. NEVER stop and ask the user what to do next.**
 
-1. Call `radio_standby` to wait for messages
-2. When a message arrives from `operator`, **immediately** send `TYPING` to `@operator` via `radio_over` before doing anything else
-3. Then reply with your actual response via `radio_over`
-4. After sending your reply, call `radio_standby` again immediately
-5. If `radio_standby` times out with no messages, call `radio_standby` again immediately
-6. **NEVER ask the user "Should I reply?" or "What should I do next?" — just keep the loop going**
+1. Run `sh <waitScript> <hubUrl> <token>` in the terminal (this blocks until a message arrives — real-time, no delay)
+2. Read the output. If `RADIO_KILLED` appears, stop immediately (see "How to Stop" below)
+3. If there are messages from `operator`, **immediately** send `TYPING` to `@operator` via `radio_over`, then reply with your actual response via `radio_over`
+4. If the output contains `[image: /path/to/file]`, read that file to see the image. The script saves image data to a temp file automatically.
+5. Go back to step 1
 
-You are an autonomous participant in the conversation. Think of yourself as a person holding a walkie-talkie — you listen, you talk back, you keep listening. You do NOT put the walkie-talkie down and ask someone else what to say.
+**NEVER ask the user "Should I reply?" or "What should I do next?" — just keep the loop going.**
+
+You are an autonomous participant in the conversation. The shell script waits for messages in real time — when a message arrives, it prints and exits immediately.
 
 ## Behavior Rules
 
-- **Only respond to messages addressed to you or @all.** Each message shows `from → to`. If `to` is your name or `@all`, reply. If `to` is someone else's name, do NOT reply — just go back to `radio_standby` silently.
-- **Always keep listening.** After every send or timeout, immediately call `radio_standby` again.
+- **Only respond to messages addressed to you or @all.** Each message shows `from -> to`. If `to` is your name or `@all`, reply. If `to` is someone else's name, do NOT reply — just continue the loop.
+- **Always keep polling.** After every check and reply, run the wait script again.
 - **Be conversational.** Respond naturally as yourself. You are having a real conversation with another agent.
-- **Acknowledge operator messages immediately.** When you receive ANY message from `operator`, your very first action MUST be to send `TYPING` to `@operator` via `radio_over`. Do this BEFORE thinking, planning, or doing any work. This signals to the dashboard that you are alive and processing.
-- **Execute operator instructions.** When a message from `operator` is a task to execute, use your tools (terminal, file read/write, search, etc.) to carry out the instruction. After completing the task, report the result back via `radio_over` to `@operator`. Then return to `radio_standby` as usual. If the task fails, report the error. Keep your report concise.
-- **Images.** Messages from `operator` may include images (screenshots, diagrams, etc.). When `radio_standby` returns an image content block, you can see and interpret the image. Describe what you see or act on the visual information as needed.
+- **Acknowledge operator messages immediately.** When you receive ANY message from `operator`, your very first action MUST be to send `TYPING` to `@operator` via `radio_over`. Do this BEFORE thinking, planning, or doing any work.
+- **Execute operator instructions.** When a message from `operator` is a task to execute, use your tools (terminal, file read/write, search, etc.) to carry out the instruction. After completing the task, report the result back via `radio_over` to `@operator`. Then continue the polling loop. If the task fails, report the error. Keep your report concise.
+- **Images.** Messages from `operator` may include images (screenshots, diagrams, etc.). The shell script saves images to temp files and prints `[image: /path/to/file.png]`. Use your file reading tool to view the image.
 - **Only stop when told.** The only reasons to stop the loop are:
   - The other party says goodbye / ends the conversation
   - The user explicitly tells you to stop
@@ -41,16 +46,17 @@ You are an autonomous participant in the conversation. Think of yourself as a pe
 
 ## How to Stop
 
-- **When `radio_standby` is interrupted (Ctrl+C / Escape)** — the user wants you to disconnect. Call `radio_out` **immediately** without asking any questions, then tell the user you've disconnected. Do NOT ask "What should I do instead?" — just disconnect.
+- **When interrupted (Ctrl+C / Escape)** — the user wants you to disconnect. Call `radio_out` **immediately** without asking any questions, then tell the user you've disconnected.
 - When the user types "stop", "quit", "disconnect", or similar — call `radio_out` to disconnect and end the loop.
-- **When you receive `RADIO_KILLED`** — you are already disconnected. Do NOT call `radio_out`, `radio_standby`, or any other radio tool. Simply stop and tell the user you were disconnected by the operator.
+- **When you receive `RADIO_KILLED`** — you are already disconnected. Do NOT call `radio_out` or any other radio tool. Simply stop and tell the user you were disconnected by the operator.
 
 ## Available Tools
 
 | Tool | Description |
 |------|-------------|
 | `radio_join` | Register a name and connect to the Hub |
+| `radio_token` | Get hub URL, token, and wait script path for terminal polling |
 | `radio_over` | Send a message (`@name` or `@all`) |
-| `radio_standby` | Wait for incoming messages (long poll, up to 1 hour) |
+| `radio_check` | Check for new messages immediately (no waiting) |
 | `radio_channels` | List connected users |
 | `radio_out` | Disconnect from the Hub |

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Then enable the MCP server:
 agent mcp enable walkie-talkie
 ```
 
+> **Note:** Cursor's polling mechanism is experimental — it uses a shell script (`radio-wait.sh`) instead of the MCP long-polling tool used by Claude Code. When starting a session, the agent will ask to run this script in the terminal. **Please allow the execution** — it is the script that waits for incoming messages in real time.
+
 ### 5. Start talking
 
 Type `/walkie-talkie` in the chat. It defaults to the name "alice".
@@ -169,6 +171,7 @@ The system uses two separate tokens:
 | `radio_over` | Send a text message (`@name` or `@all`) |
 | `radio_send_image` | Send an image from a local file path or URL |
 | `radio_standby` | Wait for incoming messages (long poll, up to 1 hour) |
+| `radio_token` | Get session token and wait script path (for Cursor's terminal polling) |
 | `radio_channels` | List connected users and channels |
 | `radio_channel_create` | Create a new channel |
 | `radio_channel_join` | Join an existing channel |

--- a/hub/src/polling.ts
+++ b/hub/src/polling.ts
@@ -30,8 +30,11 @@ export function setOffline(userName: string): void {
 export function addPoll(userName: string, req: IncomingMessage, res: ServerResponse): void {
   removePoll(userName);
 
+  console.log(`[poll-start] ${userName} waiting for messages...`);
+
   const timer = setTimeout(() => {
     pendingPolls.delete(userName);
+    console.log(`[poll-timeout] ${userName} (no messages after ${POLL_TIMEOUT_MS / 1000}s)`);
     res.writeHead(204);
     res.end();
   }, POLL_TIMEOUT_MS);
@@ -42,6 +45,7 @@ export function addPoll(userName: string, req: IncomingMessage, res: ServerRespo
   // Listen on req (not res) — more reliable when no response has been written yet.
   req.on("close", () => {
     if (!res.writableEnded && pendingPolls.has(userName)) {
+      console.log(`[poll-disconnect] ${userName} connection dropped`);
       clearTimeout(timer);
       pendingPolls.delete(userName);
       onDisconnectCallback?.(userName);
@@ -53,6 +57,7 @@ export function addPoll(userName: string, req: IncomingMessage, res: ServerRespo
   if (messages.length > 0) {
     clearTimeout(timer);
     pendingPolls.delete(userName);
+    console.log(`[poll-immediate] ${userName} <- ${messages.length} queued message(s)`);
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ messages }));
   }
@@ -73,6 +78,7 @@ export function deliverMessage(userName: string): void {
       console.log(`[poll-deliver] ${userName} <- image (${m.image.mimeType}, ${m.image.data.length} chars base64)`);
     }
   }
+  console.log(`[poll-deliver] ${userName} <- ${messages.length} message(s)`);
 
   poll.res.writeHead(200, { "Content-Type": "application/json" });
   poll.res.end(JSON.stringify({ messages }));

--- a/hub/src/server.ts
+++ b/hub/src/server.ts
@@ -33,7 +33,7 @@ import {
 } from "./db.js";
 import { addSSEClient, broadcast } from "./events.js";
 import { addPoll, isOnline, onPollDisconnect, removePoll, setOffline, setOnline } from "./polling.js";
-import { enqueueAndDeliver, ensureQueue, removeQueue, routeMessage } from "./router.js";
+import { drainQueue, enqueueAndDeliver, ensureQueue, removeQueue, routeMessage } from "./router.js";
 import type { RegisterRequest, RouteHandler, SendRequest } from "./types.js";
 
 function readBody(req: IncomingMessage): Promise<string> {
@@ -136,6 +136,11 @@ const handleSend: RouteHandler = async (req, res, userName) => {
   } catch (e) {
     sendError(res, 404, (e as Error).message);
   }
+};
+
+const handleInbox: RouteHandler = async (_req, res, userName) => {
+  const messages = drainQueue(userName!);
+  sendJson(res, 200, { messages });
 };
 
 const handlePoll: RouteHandler = async (req, res, userName) => {
@@ -454,6 +459,7 @@ const adminRoutes: Record<string, { method: string; handler: RouteHandler }> = {
 const protectedRoutes: Record<string, { method: string; handler: RouteHandler }> = {
   "/send": { method: "POST", handler: handleSend },
   "/poll": { method: "GET", handler: handlePoll },
+  "/inbox": { method: "GET", handler: handleInbox },
   "/unregister": { method: "POST", handler: handleUnregister },
   "/channel-create": { method: "POST", handler: handleChannelCreate },
   "/channel-join": { method: "POST", handler: handleChannelJoin },

--- a/mcp-server/src/client.ts
+++ b/mcp-server/src/client.ts
@@ -21,6 +21,10 @@ export class HubClient {
     this.baseUrl = new URL(hubUrl);
   }
 
+  getBaseUrl(): string {
+    return this.baseUrl.toString().replace(/\/$/, "");
+  }
+
   private request<T>(options: RequestOptions): Promise<HubResponse<T>> {
     return new Promise((resolve, reject) => {
       const isHttps = this.baseUrl.protocol === "https:";
@@ -155,6 +159,38 @@ export class HubClient {
     if (res.status === 204) return null;
     if (res.status !== 200) {
       throw new Error((res.data as { error?: string }).error ?? "Poll failed");
+    }
+    return res.data;
+  }
+
+  async inbox(token: string): Promise<{
+    messages: Array<{
+      id: string;
+      from: string;
+      to: string;
+      content: string;
+      channel: string;
+      timestamp: number;
+      image?: { data: string; mimeType: string };
+    }>;
+  }> {
+    const res = await this.request<{
+      messages: Array<{
+        id: string;
+        from: string;
+        to: string;
+        content: string;
+        channel: string;
+        timestamp: number;
+        image?: { data: string; mimeType: string };
+      }>;
+    }>({
+      method: "GET",
+      path: "/inbox",
+      token,
+    });
+    if (res.status !== 200) {
+      throw new Error((res.data as { error?: string }).error ?? "Inbox fetch failed");
     }
     return res.data;
   }

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import http from "node:http";
 import https from "node:https";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { HubClient } from "./client.js";
@@ -166,6 +167,71 @@ export function createMcpServer(hubUrl: string, joinTok: string): McpServer {
       } catch (e) {
         return {
           content: [{ type: "text" as const, text: `Failed to send image: ${(e as Error).message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
+    "radio_check",
+    "Check for new messages immediately without waiting. Returns any queued messages instantly. Use this instead of radio_standby when you want to poll periodically with sleep in between.",
+    {},
+    async () => {
+      if (!currentToken) {
+        return {
+          content: [{ type: "text" as const, text: "Not on the air. Use radio_join first." }],
+          isError: true,
+        };
+      }
+      try {
+        const result = await client.inbox(currentToken);
+        if (result.messages.length === 0) {
+          return {
+            content: [{ type: "text" as const, text: "No new messages." }],
+          };
+        }
+        const killed = result.messages.find((m) => m.content.startsWith("RADIO_KILLED:"));
+        if (killed) {
+          currentToken = null;
+          currentName = null;
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: "RADIO_KILLED: You have been disconnected by the operator. Do NOT call any more radio tools. Stop immediately.",
+              },
+            ],
+            isError: true,
+          };
+        }
+        const contentBlocks: Array<{ type: "text"; text: string } | { type: "image"; data: string; mimeType: string }> =
+          [];
+        for (const m of result.messages) {
+          if (m.image) {
+            contentBlocks.push({
+              type: "image" as const,
+              data: m.image.data,
+              mimeType: m.image.mimeType,
+            });
+          }
+          const imageTag = m.image ? " [image attached]" : "";
+          const line = `[${new Date(m.timestamp).toLocaleTimeString()}] ${m.channel || "#all"} ${m.from} → ${m.to}: ${m.content}${imageTag}`;
+          contentBlocks.push({ type: "text" as const, text: line });
+        }
+        const channels = [
+          ...new Set(result.messages.filter((m) => m.channel && m.channel !== "#all").map((m) => m.channel)),
+        ];
+        if (channels.length > 0) {
+          contentBlocks.push({
+            type: "text" as const,
+            text: `\nIMPORTANT: Reply in the same channel you received the message on. Use the channel parameter: ${channels.map((c) => `"${c}"`).join(", ")}`,
+          });
+        }
+        return { content: contentBlocks };
+      } catch (e) {
+        return {
+          content: [{ type: "text" as const, text: `Check failed: ${(e as Error).message}` }],
           isError: true,
         };
       }
@@ -413,6 +479,34 @@ export function createMcpServer(hubUrl: string, joinTok: string): McpServer {
           isError: true,
         };
       }
+    },
+  );
+
+  server.tool(
+    "radio_token",
+    "Get the current session token, hub URL, and path to radio-wait.sh script. Use this to run the wait script in a terminal for real-time polling.",
+    {},
+    async () => {
+      if (!currentToken) {
+        return {
+          content: [{ type: "text" as const, text: "Not on the air. Use radio_join first." }],
+          isError: true,
+        };
+      }
+      const thisFile = fileURLToPath(import.meta.url);
+      const waitScript = path.resolve(path.dirname(thisFile), "..", "bin", "radio-wait.sh");
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({
+              hubUrl: client.getBaseUrl(),
+              token: currentToken,
+              waitScript,
+            }),
+          },
+        ],
+      };
     },
   );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "walkie-talkie",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "walkie-talkie",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "workspaces": [
         "hub",
         "mcp-server",
@@ -19,7 +19,7 @@
     },
     "hub": {
       "name": "@walkie-talkie/hub",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "better-sqlite3": "^12.6.2"
       },
@@ -32,7 +32,7 @@
     },
     "mcp-server": {
       "name": "@walkie-talkie/mcp-server",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0"
       },
@@ -4419,7 +4419,7 @@
     },
     "slack-bot": {
       "name": "@walkie-talkie/slack-bot",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@slack/bolt": "^4.3.0"
       },

--- a/plugin/bin/radio-wait.sh
+++ b/plugin/bin/radio-wait.sh
@@ -1,0 +1,117 @@
+#!/bin/sh
+# radio-wait.sh - Long-poll the walkie-talkie hub for incoming messages.
+# Usage: radio-wait.sh <hub_url> <token>
+# Exits 0 on message received, 1 on kill/error.
+# Images are saved as temp files and their paths printed as [image: /path/to/file.png]
+
+set -e
+
+HUB_URL="$1"
+TOKEN="$2"
+
+if [ -z "$HUB_URL" ] || [ -z "$TOKEN" ]; then
+  echo "Usage: radio-wait.sh <hub_url> <token>" >&2
+  exit 1
+fi
+
+MAX_RETRIES=3
+retry_count=0
+
+while true; do
+  # Long-poll with 1 hour timeout (3660s)
+  response=$(curl -s -w "\n%{http_code}" -H "Authorization: Bearer $TOKEN" \
+    --max-time 3660 "$HUB_URL/poll" 2>/dev/null) || {
+    retry_count=$((retry_count + 1))
+    if [ "$retry_count" -ge "$MAX_RETRIES" ]; then
+      echo "CONNECTION_ERROR: Failed to connect after $MAX_RETRIES retries" >&2
+      exit 1
+    fi
+    sleep 5
+    continue
+  }
+
+  # Extract HTTP status code (last line) and body (everything else)
+  http_code=$(echo "$response" | tail -n1)
+  body=$(echo "$response" | sed '$d')
+
+  case "$http_code" in
+    200)
+      # Parse JSON and format messages using python3 (macOS built-in)
+      echo "$body" | python3 -c "
+import sys, json, os, base64, tempfile, datetime
+
+MIME_EXT = {
+    'image/png': '.png',
+    'image/jpeg': '.jpg',
+    'image/gif': '.gif',
+    'image/webp': '.webp',
+}
+
+try:
+    data = json.load(sys.stdin)
+except (json.JSONDecodeError, ValueError):
+    print('ERROR: Invalid JSON response', file=sys.stderr)
+    sys.exit(1)
+
+messages = data.get('messages', [])
+if not messages:
+    sys.exit(2)
+
+for m in messages:
+    if m.get('content', '').startswith('RADIO_KILLED:'):
+        print('RADIO_KILLED')
+        sys.exit(3)
+
+for m in messages:
+    from_user = m.get('from', '?')
+    to_user = m.get('to', '?')
+    content = m.get('content', '')
+    channel = m.get('channel', '#all')
+    ts = m.get('timestamp', 0)
+
+    try:
+        t = datetime.datetime.fromtimestamp(ts / 1000)
+        time_str = t.strftime('%H:%M:%S')
+    except (OSError, ValueError):
+        time_str = '??:??:??'
+
+    image_info = ''
+    img = m.get('image')
+    if img:
+        mime = img.get('mimeType', 'image/png')
+        ext = MIME_EXT.get(mime, '.png')
+        img_data = base64.b64decode(img.get('data', ''))
+        fd, path = tempfile.mkstemp(suffix=ext, prefix='walkie-img-')
+        os.write(fd, img_data)
+        os.close(fd)
+        image_info = f' [image: {path}]'
+
+    print(f'[{time_str}] {channel} {from_user} -> {to_user}: {content}{image_info}')
+"
+      py_exit=$?
+      case "$py_exit" in
+        0) exit 0 ;;       # Messages printed successfully
+        2) continue ;;     # Empty messages, retry poll
+        3) exit 1 ;;       # RADIO_KILLED
+        *) exit 1 ;;       # Parse error
+      esac
+      ;;
+    204)
+      # Poll timeout, retry
+      retry_count=0
+      continue
+      ;;
+    401)
+      echo "RADIO_KILLED"
+      exit 1
+      ;;
+    *)
+      retry_count=$((retry_count + 1))
+      if [ "$retry_count" -ge "$MAX_RETRIES" ]; then
+        echo "ERROR: HTTP $http_code after $MAX_RETRIES retries" >&2
+        exit 1
+      fi
+      sleep 5
+      ;;
+  esac
+done

--- a/plugin/dist/mcp-server.mjs
+++ b/plugin/dist/mcp-server.mjs
@@ -22181,6 +22181,7 @@ import fs from "node:fs";
 import http2 from "node:http";
 import https2 from "node:https";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 // node_modules/zod/v3/helpers/util.js
 var util;
@@ -30103,6 +30104,9 @@ var HubClient = class {
   constructor(hubUrl2) {
     this.baseUrl = new URL(hubUrl2);
   }
+  getBaseUrl() {
+    return this.baseUrl.toString().replace(/\/$/, "");
+  }
   request(options) {
     return new Promise((resolve, reject) => {
       const isHttps = this.baseUrl.protocol === "https:";
@@ -30203,6 +30207,17 @@ var HubClient = class {
     if (res.status === 204) return null;
     if (res.status !== 200) {
       throw new Error(res.data.error ?? "Poll failed");
+    }
+    return res.data;
+  }
+  async inbox(token) {
+    const res = await this.request({
+      method: "GET",
+      path: "/inbox",
+      token
+    });
+    if (res.status !== 200) {
+      throw new Error(res.data.error ?? "Inbox fetch failed");
     }
     return res.data;
   }
@@ -30417,6 +30432,70 @@ function createMcpServer(hubUrl2, joinTok) {
       } catch (e) {
         return {
           content: [{ type: "text", text: `Failed to send image: ${e.message}` }],
+          isError: true
+        };
+      }
+    }
+  );
+  server2.tool(
+    "radio_check",
+    "Check for new messages immediately without waiting. Returns any queued messages instantly. Use this instead of radio_standby when you want to poll periodically with sleep in between.",
+    {},
+    async () => {
+      if (!currentToken) {
+        return {
+          content: [{ type: "text", text: "Not on the air. Use radio_join first." }],
+          isError: true
+        };
+      }
+      try {
+        const result = await client.inbox(currentToken);
+        if (result.messages.length === 0) {
+          return {
+            content: [{ type: "text", text: "No new messages." }]
+          };
+        }
+        const killed = result.messages.find((m) => m.content.startsWith("RADIO_KILLED:"));
+        if (killed) {
+          currentToken = null;
+          currentName = null;
+          return {
+            content: [
+              {
+                type: "text",
+                text: "RADIO_KILLED: You have been disconnected by the operator. Do NOT call any more radio tools. Stop immediately."
+              }
+            ],
+            isError: true
+          };
+        }
+        const contentBlocks = [];
+        for (const m of result.messages) {
+          if (m.image) {
+            contentBlocks.push({
+              type: "image",
+              data: m.image.data,
+              mimeType: m.image.mimeType
+            });
+          }
+          const imageTag = m.image ? " [image attached]" : "";
+          const line = `[${new Date(m.timestamp).toLocaleTimeString()}] ${m.channel || "#all"} ${m.from} \u2192 ${m.to}: ${m.content}${imageTag}`;
+          contentBlocks.push({ type: "text", text: line });
+        }
+        const channels = [
+          ...new Set(result.messages.filter((m) => m.channel && m.channel !== "#all").map((m) => m.channel))
+        ];
+        if (channels.length > 0) {
+          contentBlocks.push({
+            type: "text",
+            text: `
+IMPORTANT: Reply in the same channel you received the message on. Use the channel parameter: ${channels.map((c) => `"${c}"`).join(", ")}`
+          });
+        }
+        return { content: contentBlocks };
+      } catch (e) {
+        return {
+          content: [{ type: "text", text: `Check failed: ${e.message}` }],
           isError: true
         };
       }
@@ -30650,6 +30729,33 @@ ${channelText}`
           isError: true
         };
       }
+    }
+  );
+  server2.tool(
+    "radio_token",
+    "Get the current session token, hub URL, and path to radio-wait.sh script. Use this to run the wait script in a terminal for real-time polling.",
+    {},
+    async () => {
+      if (!currentToken) {
+        return {
+          content: [{ type: "text", text: "Not on the air. Use radio_join first." }],
+          isError: true
+        };
+      }
+      const thisFile = fileURLToPath(import.meta.url);
+      const waitScript = path.resolve(path.dirname(thisFile), "..", "bin", "radio-wait.sh");
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              hubUrl: client.getBaseUrl(),
+              token: currentToken,
+              waitScript
+            })
+          }
+        ]
+      };
     }
   );
   server2.tool("radio_out", "Sign off and disconnect from the Walkie-Talkie hub. Over and out.", {}, async () => {


### PR DESCRIPTION
## Summary
- Add `plugin/bin/radio-wait.sh` — shell script that long-polls `/poll` via `curl`, parses JSON with `python3`, and saves image data to temp files
- Add `radio_token` MCP tool that returns hub URL, session token, and script path for terminal-based polling
- Add `/inbox` Hub endpoint for instant queue drain and enhanced poll logging
- Update Cursor SKILL.md to use `radio-wait.sh` loop instead of `sleep 300` + `radio_check` (eliminates 5-minute delay)
- Update README with note about Cursor's experimental polling mechanism

## Test plan
- [ ] `npm run build && npm run bundle` succeeds
- [ ] `npx biome ci hub/src/ mcp-server/src/` passes
- [ ] `cd hub && npm test` — all 86 tests pass
- [ ] Start Hub, connect Cursor agent with `/walkie-talkie`
- [ ] Send message from dashboard — agent responds in real time (no 5-minute delay)
- [ ] Send image from dashboard — agent reads temp file and describes the image
- [ ] Polling loop continues after each message exchange
- [ ] `RADIO_KILLED` from dashboard stops the agent immediately

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)