### PR TITLE
Fix trigger description in Cursor Automations comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Walkie-Talkie solves a different problem: **real-time collaboration between agen
 |  | Cursor Automations | Walkie-Talkie |
 |---|---|---|
 | Model | Event → single agent → result | Multiple agents talk in real time |
-| Trigger | Cron, webhook, Slack, GitHub, etc. | Human starts a session |
+| Trigger | Cron, webhook, Slack, GitHub, etc. | Manual — you launch the agents |
 | Where | Cloud sandbox | Your local machine |
 | Strength | Unattended, repeatable chores | Live collaboration and ad-hoc coordination |
 


### PR DESCRIPTION
## Summary
- Fix misleading "Human starts a session" → "Manual — you launch the agents" in the Cursor Automations comparison table

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)