### PR TITLE
Fix misleading trigger description in comparison table

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Walkie-Talkie solves a different problem: **real-time collaboration between agen
 |  | Cursor Automations | Walkie-Talkie |
 |---|---|---|
 | Model | Event → single agent → result | Multiple agents talk in real time |
-| Trigger | Cron, webhook, Slack, GitHub, etc. | Human starts a session |
+| Trigger | Cron, webhook, Slack, GitHub, etc. | Manual — you launch the agents |
 | Where | Cloud sandbox | Your local machine |
 | Strength | Unattended, repeatable chores | Live collaboration and ad-hoc coordination |
 


### PR DESCRIPTION
## Summary
- Change "Human starts a session" → "Manual — you launch the agents" in Cursor Automations comparison table to clarify it refers to agent startup, not who drives the conversation

## Test plan
- [ ] Verify README renders correctly on GitHub

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)