### PR TITLE
Add client role (agent/bridge) for relay services

### DIFF
--- a/hub/src/auth.ts
+++ b/hub/src/auth.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from "node:crypto";
 import type { IncomingMessage } from "node:http";
 import { removeUserFromAllChannels } from "./channels.js";
-import type { User } from "./types.js";
+import type { User, UserRole } from "./types.js";
 
 const users = new Map<string, User>();
 const tokenToName = new Map<string, string>();
@@ -10,12 +10,12 @@ export function getUserToken(name: string): string | null {
   return users.get(name)?.token ?? null;
 }
 
-export function registerUser(name: string): User {
+export function registerUser(name: string, role: UserRole = "agent"): User {
   if (users.has(name)) {
     throw new Error(`User "${name}" is already registered`);
   }
   const token = randomBytes(32).toString("hex");
-  const user: User = { name, token, registeredAt: Date.now() };
+  const user: User = { name, token, role, registeredAt: Date.now() };
   users.set(name, user);
   tokenToName.set(token, name);
   return user;
@@ -39,6 +39,10 @@ export function authenticateRequest(req: IncomingMessage): string | null {
 
 export function getRegisteredUsers(): string[] {
   return Array.from(users.keys());
+}
+
+export function getUserRole(name: string): UserRole | null {
+  return users.get(name)?.role ?? null;
 }
 
 export function isUserRegistered(name: string): boolean {

--- a/hub/src/router.ts
+++ b/hub/src/router.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { isUserRegistered } from "./auth.js";
+import { getUserRole, isUserRegistered } from "./auth.js";
 import { getChannelMembers, isChannelMember } from "./channels.js";
 import { dbSaveMessage } from "./db.js";
 import { deliverMessage } from "./polling.js";
@@ -47,11 +47,14 @@ export function routeMessage(
 
     dbSaveMessage(message);
 
-    // Deliver to all channel members except sender
+    const senderRole = getUserRole(from);
+
+    // Deliver to all channel members except sender.
+    // When a bridge sends @all, skip other bridges to avoid relay loops.
     for (const user of members) {
-      if (user !== from) {
-        enqueueAndDeliver(user, message);
-      }
+      if (user === from) continue;
+      if (senderRole === "bridge" && getUserRole(user) === "bridge") continue;
+      enqueueAndDeliver(user, message);
     }
     return message;
   }

--- a/hub/src/server.ts
+++ b/hub/src/server.ts
@@ -3,6 +3,7 @@ import { createServer, type IncomingMessage, type ServerResponse } from "node:ht
 import {
   authenticateRequest,
   getRegisteredUsers,
+  getUserRole,
   getUserToken,
   isUserRegistered,
   registerUser,
@@ -76,7 +77,8 @@ const handleRegister: RouteHandler = async (req, res) => {
       clearTimeout(graceTimer);
       staleTimers.delete(body.name);
     }
-    const user = registerUser(body.name);
+    const role = body.role === "bridge" ? "bridge" : "agent";
+    const user = registerUser(body.name, role);
     ensureQueue(body.name);
     setOnline(body.name);
     // Auto-join #all
@@ -156,6 +158,7 @@ const handleUsers: RouteHandler = async (_req, res) => {
   const users = getRegisteredUsers().map((name) => ({
     name,
     online: isOnline(name),
+    role: getUserRole(name) ?? "agent",
   }));
   sendJson(res, 200, { users });
 };

--- a/hub/src/types.ts
+++ b/hub/src/types.ts
@@ -15,15 +15,19 @@ export interface Message {
   image?: MessageImage;
 }
 
+export type UserRole = "agent" | "bridge";
+
 export interface User {
   name: string;
   token: string;
+  role: UserRole;
   registeredAt: number;
 }
 
 export interface RegisterRequest {
   name: string;
   oldToken?: string;
+  role?: UserRole;
 }
 
 export interface RegisterResponse {

--- a/subsystems/slack-bot/src/index.ts
+++ b/subsystems/slack-bot/src/index.ts
@@ -40,7 +40,7 @@ async function hubRegister(): Promise<void> {
         "Content-Type": "application/json",
         Authorization: `Bearer ${JOIN_TOKEN}`,
       },
-      body: JSON.stringify({ name: BOT_NAME, oldToken: hubToken }),
+      body: JSON.stringify({ name: BOT_NAME, oldToken: hubToken, role: "bridge" }),
     });
     if (res.ok) {
       const data = (await res.json()) as { token: string; name: string };
@@ -80,6 +80,19 @@ interface HubMessage {
   content: string;
   channel: string;
   timestamp: number;
+}
+
+interface HubUser {
+  name: string;
+  online: boolean;
+  role: string;
+}
+
+async function hubGetAgents(): Promise<HubUser[]> {
+  const res = await fetch(`${HUB_URL}/users`);
+  if (!res.ok) return [];
+  const data = (await res.json()) as { users: HubUser[] };
+  return data.users.filter((u) => u.role === "agent" && u.online);
 }
 
 async function hubPoll(): Promise<HubMessage[]> {
@@ -211,6 +224,13 @@ async function main(): Promise<void> {
 
     const { to, content } = parseCommand(rawText);
 
+    // Check if any agents are connected
+    const agents = await hubGetAgents();
+    if (agents.length === 0) {
+      await say({ text: "No agents are currently connected to the Hub.", thread_ts: event.ts });
+      return;
+    }
+
     // Post "thinking..." in thread
     const thinkingRes = await say({ text: `_thinking... (sending to ${to})_`, thread_ts: event.ts });
 
@@ -262,6 +282,13 @@ async function main(): Promise<void> {
     if (to === "@all" && threadAgents.has(threadTs)) {
       to = threadAgents.get(threadTs)!;
       content = rawText;
+    }
+
+    // Check if any agents are connected
+    const agents = await hubGetAgents();
+    if (agents.length === 0) {
+      await say({ text: "No agents are currently connected to the Hub.", thread_ts: threadTs });
+      return;
     }
 
     // Track pending reply for the thread


### PR DESCRIPTION
## Summary
- Add `UserRole` type (`"agent"` | `"bridge"`) to Hub registration
- When a bridge sends `@all`, other bridges are excluded from delivery (prevents relay loops)
- `/users` endpoint now returns `role` for each user
- Slack bot registers as `"bridge"` and checks for online agents before sending — shows "No agents are currently connected" instead of a dangling "thinking..."

## Test plan
- [ ] `npm run build` succeeds (all 3 workspaces)
- [ ] `npx biome ci hub/src/ mcp-server/src/ subsystems/slack-bot/src/` passes
- [ ] `cd hub && npm test` — all 86 tests pass
- [ ] Start Hub + Slack bot without agents → Slack message shows "No agents are currently connected"
- [ ] Start Hub + Slack bot + agent → Slack message reaches agent and reply comes back
- [ ] `GET /users` returns `role: "bridge"` for slack and `role: "agent"` for agents
- [ ] Two bridges on the Hub: bridge A sends @all → bridge B does NOT receive it

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)