### PR TITLE
Use @@ prefix for agent targeting in Slack bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Agent A ──stdio──> MCP Server ──HTTP──> Hub ──HTTP──> MC
 (Claude Code, Cursor, etc.)             │             (Claude Code, Cursor, etc.)
                                         │
                                    Dashboard          Slack Bot ──Socket Mode──> Slack
-                                 (ON-AIR screen)      (@walkie-talkie @alice ...)
+                                 (ON-AIR screen)      (@walkie-talkie @@alice ...)
 ```
 
 ## 🤔 How is this different from multi-agent frameworks?
@@ -164,7 +164,7 @@ agent mcp enable walkie-talkie
 A Slack bot bridges your Slack workspace and the Hub. Mention the bot in Slack to talk to connected agents:
 
 ```
-@walkie-talkie @alice Please review the PR
+@walkie-talkie @@alice Please review the PR
 ```
 
 The bot replies in a thread, and you can continue the conversation there.

--- a/subsystems/slack-bot/README.md
+++ b/subsystems/slack-bot/README.md
@@ -3,7 +3,7 @@
 A Slack bot that bridges Slack and the Walkie-Talkie Hub. Users can mention the bot in Slack to send messages to AI agents connected to the Hub.
 
 ```
-Slack (@walkie-talkie @alice do something)
+Slack (@walkie-talkie @@alice do something)
   ↓
 slack-bot (Socket Mode) ──HTTP──> Hub ──> Claude Code (alice)
   ↑                                           │
@@ -105,7 +105,7 @@ The bot also appears on the Hub dashboard as `slack`.
 In any Slack channel where the bot is invited:
 
 ```
-@walkie-talkie @alice Please review the PR       → sends to agent "alice"
+@walkie-talkie @@alice Please review the PR       → sends to agent "alice"
 @walkie-talkie What is the project status?        → sends to @all (all connected agents)
 ```
 
@@ -115,7 +115,7 @@ The bot will:
 2. Forward the message to the Hub
 3. Post the agent's response in the same thread
 
-You can continue the conversation by replying in the same thread — no need to `@mention` the bot again. To specify a different agent in the thread, use `@alice message`.
+You can continue the conversation by replying in the same thread — no need to `@mention` the bot again. To specify a different agent in the thread, use `@@alice message`.
 
 ## Troubleshooting
 

--- a/subsystems/slack-bot/src/index.ts
+++ b/subsystems/slack-bot/src/index.ts
@@ -224,14 +224,14 @@ function stripBotMention(text: string): string {
 }
 
 // ---------------------------------------------------------------------------
-// Parse mention text: "@walkie-talkie @alice do something" or "@walkie-talkie do something"
+// Parse mention text: "@walkie-talkie @@alice do something" or "@walkie-talkie do something"
 // ---------------------------------------------------------------------------
 
 function parseCommand(text: string): { to: string; content: string } {
   const trimmed = text.trim();
 
-  // Check if the first word is @someone
-  const match = trimmed.match(/^@(\S+)\s+([\s\S]*)$/);
+  // Check if the first token is @@someone (double-@ to avoid Slack mention confusion)
+  const match = trimmed.match(/^@@(\S+)\s+([\s\S]*)$/);
   if (match) {
     return { to: `@${match[1]}`, content: match[2].trim() };
   }
@@ -257,7 +257,7 @@ async function main(): Promise<void> {
 
     if (!rawText) {
       await say({
-        text: "Usage: `@walkie-talkie @agent-name message` or `@walkie-talkie message`",
+        text: "Usage: `@walkie-talkie @@agent-name message` or `@walkie-talkie message`",
         thread_ts: event.ts,
       });
       return;


### PR DESCRIPTION
## Summary
- Change agent targeting syntax from `@alice` to `@@alice` to avoid confusion with Slack's native @mentions
- Update `parseCommand` regex to match `@@(\S+)` pattern
- Update usage message and both READMEs

## Test plan
- [x] `@walkie-talkie @@alice hello` → sends to agent "alice"
- [x] `@walkie-talkie hello` → sends to @all (unchanged)
- [ ] Thread reply `@@bob hello` → sends to agent "bob"
- [x] Thread reply without `@@` → sends to last agent in thread (unchanged)

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)