### PR TITLE
Show @@ prefix in agent reply display name

### DIFF
--- a/subsystems/slack-bot/src/index.ts
+++ b/subsystems/slack-bot/src/index.ts
@@ -191,7 +191,7 @@ async function pollLoop(): Promise<void> {
           await slackApp.client.chat.postMessage({
             channel: pending.slackChannel,
             thread_ts: pending.threadTs,
-            text: `*${msg.from}*:\n${msg.content}`,
+            text: `*@@${msg.from}*:\n${msg.content}`,
           });
         } else {
           // No pending reply — post as a new message to a default channel if configured


### PR DESCRIPTION
## Summary
- Display agent replies as `**@@alice**:` instead of `**alice**:` in Slack threads
- Consistent with the `@@` targeting syntax introduced in #102

## Test plan
- [x] Send a message via `@walkie-talkie` and verify the reply shows `@@alice:` format

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)