### PR TITLE
Restore terminal to cooked mode on shutdown

### DIFF
--- a/hub/src/index.ts
+++ b/hub/src/index.ts
@@ -37,6 +37,10 @@ let shuttingDown = false;
 function handleShutdown(): void {
   if (shuttingDown) return;
   shuttingDown = true;
+  // Restore terminal to cooked mode if it was set to raw
+  if (process.stdin.isTTY && process.stdin.isRaw) {
+    process.stdin.setRawMode(false);
+  }
   console.log("\n[shutdown] Notifying connected users...");
   // Send RADIO_KILLED to all connected users so they disconnect gracefully
   for (const name of getRegisteredUsers()) {


### PR DESCRIPTION
## Summary
- Reset `process.stdin.setRawMode(false)` in the shutdown handler before exiting
- Prevents the terminal from staying in raw mode after Ctrl+C, which caused arrow keys to print `^[[A` instead of navigating history

## Test plan
- [x] `npm run build` passes
- [x] `cd hub && npm test` — 104 tests pass
- [x] Start Hub with a connected agent, press Ctrl+C, verify arrow keys work normally

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)