### PR TITLE
Remove Claude-specific hints from agent launcher

### DIFF
--- a/hub/src/__tests__/api-agent-launcher.test.ts
+++ b/hub/src/__tests__/api-agent-launcher.test.ts
@@ -4,8 +4,6 @@ import { startTestServer, stopTestServer, type TestContext } from "./helpers/ser
 vi.mock("../launcher.js", () => ({
   launchAgent: vi.fn(),
   autoLaunchAgents: vi.fn(),
-  resolveSkillHint: (name: string) => `/walkie-talkie:walkie-talkie ${name}`,
-  SKILL_HINT_TEMPLATE: "/walkie-talkie:walkie-talkie {{name}}",
 }));
 
 let ctx: TestContext;

--- a/hub/src/dashboard.ts
+++ b/hub/src/dashboard.ts
@@ -925,9 +925,6 @@ export function getDashboardHTML(adminToken: string): string {
         <input type="text" id="agent-dialog-name" placeholder="alice" pattern="[a-zA-Z0-9_-]+">
         <span id="agent-dialog-name-error" style="color:var(--red);font-size:11px;display:none"></span>
       </label>
-      <label>Skill command <span style="font-weight:400;color:var(--text-tertiary)">(type this after claude starts)</span>
-        <code id="agent-dialog-command" style="font-family:var(--mono);font-size:12px;padding:8px 10px;background:var(--bg-base);color:var(--text-secondary);border:1px solid var(--border-subtle);border-radius:8px;word-break:break-all">/walkie-talkie:walkie-talkie ...</code>
-      </label>
       <label>Working Directory
         <input type="text" id="agent-dialog-workdir" placeholder="/path/to/project">
       </label>
@@ -1465,23 +1462,16 @@ export function getDashboardHTML(adminToken: string): string {
     const agentDialogName = document.getElementById("agent-dialog-name");
     const agentDialogNameError = document.getElementById("agent-dialog-name-error");
     const agentDialogWorkdir = document.getElementById("agent-dialog-workdir");
-    const agentDialogCommand = document.getElementById("agent-dialog-command");
     const agentDialogAutostart = document.getElementById("agent-dialog-autostart");
 
     function updateCommandPreview() {
       const name = agentDialogName.value.trim();
       if (name && AGENT_NAME_RE.test(name)) {
-        agentDialogCommand.textContent = '/walkie-talkie:walkie-talkie ' + name;
-        agentDialogCommand.style.color = "var(--text-secondary)";
         agentDialogNameError.style.display = "none";
       } else if (name) {
-        agentDialogCommand.textContent = '/walkie-talkie:walkie-talkie ...';
-        agentDialogCommand.style.color = "var(--text-tertiary)";
         agentDialogNameError.textContent = "Use only a-z, 0-9, hyphen, underscore";
         agentDialogNameError.style.display = "block";
       } else {
-        agentDialogCommand.textContent = '/walkie-talkie:walkie-talkie ...';
-        agentDialogCommand.style.color = "var(--text-tertiary)";
         agentDialogNameError.style.display = "none";
       }
     }

--- a/hub/src/launcher.ts
+++ b/hub/src/launcher.ts
@@ -5,13 +5,7 @@ import { join } from "node:path";
 import type { AgentConfigRow } from "./db.js";
 import { dbListAgentConfigs } from "./db.js";
 
-export const SKILL_HINT_TEMPLATE = "/walkie-talkie:walkie-talkie {{name}}";
-
 let windowOpened = false;
-
-export function resolveSkillHint(name: string): string {
-  return SKILL_HINT_TEMPLATE.replace(/\{\{name\}\}/g, name);
-}
 
 function escapeAppleScript(s: string): string {
   return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
@@ -22,14 +16,12 @@ function shellQuote(s: string): string {
 }
 
 function createLaunchScript(config: AgentConfigRow): string {
-  const hint = resolveSkillHint(config.name);
   const nameBase64 = Buffer.from(config.name).toString("base64");
   const scriptPath = join(tmpdir(), `wt-launch-${config.name}-${Date.now()}.sh`);
   const script = `#!/bin/zsh
 cd ${shellQuote(config.work_dir)}
 rm -f "$0"
 printf '\\033]1337;SetBadgeFormat=${nameBase64}\\007'
-printf '\\033c>>> Run: claude\\n>>> Then type: ${hint}\\n'
 exec $SHELL
 `;
   writeFileSync(scriptPath, script, { mode: 0o755 });


### PR DESCRIPTION
## Summary
- Remove `SKILL_HINT_TEMPLATE`, `resolveSkillHint` and the `>>> Run: claude` echo from `launcher.ts`
- Remove "Skill command" preview field from the dashboard agent dialog
- Launcher now just opens an iTerm2 pane with workDir + badge — editor-agnostic

## Test plan
- [x] `npm run build` passes
- [x] `cd hub && npm test` — 104 tests pass
- [x] Launch agent from dashboard, verify clean terminal with badge only

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)