### PR TITLE
Add launcher docs to README and handle missing iTerm2 gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,24 @@ Open `http://localhost:9559` in your browser to:
 - Send messages and instructions to agents as the operator
 - Send images by pasting or dragging them into the message area (auto-resized to max 1024px)
 - Create and manage channels for scoped conversations
+- Launch and manage agents via the Agent Launcher (see below)
+
+### Agent Launcher
+
+The dashboard includes an **Agents** section for launching terminal panes from the browser. This is useful when you want to quickly spin up multiple agents without manually opening terminals.
+
+**Requirements**: [iTerm2](https://iterm2.com/) must be installed (macOS only). The launcher uses AppleScript to control iTerm2.
+
+**How it works**:
+
+1. Click **[+]** next to "Agents" in the dashboard sidebar
+2. Enter a name (e.g. `alice`) and working directory (e.g. `/path/to/project`)
+3. Click **Launch** — an iTerm2 pane opens, `cd`'d to the working directory, with the agent name as a badge
+4. Start your preferred tool (Claude Code, Cursor, etc.) in the opened terminal
+
+Multiple agents open as split panes in a single iTerm2 window. Enable **Auto-start** to launch agents automatically when the Hub starts.
+
+> **Note**: If iTerm2 is not installed, the Launch button will show an error message.
 
 ## 🔐 Authentication
 

--- a/hub/src/launcher.ts
+++ b/hub/src/launcher.ts
@@ -46,21 +46,22 @@ function openInITerm(config: AgentConfigRow): Promise<void> {
         "\n",
       );
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     execFile("osascript", ["-e", script], (err) => {
       if (err) {
         console.error(`[launcher] Failed to open iTerm2 for ${config.name}: ${err.message}`);
+        reject(new Error(`Failed to open iTerm2: ${err.message}`));
       } else {
-        console.log(`[launcher] Opened iTerm2 ${windowOpened ? "tab" : "window"} for ${config.name}`);
+        console.log(`[launcher] Opened iTerm2 ${windowOpened ? "pane" : "window"} for ${config.name}`);
         windowOpened = true;
+        resolve();
       }
-      resolve();
     });
   });
 }
 
-export function launchAgent(config: AgentConfigRow): void {
-  openInITerm(config);
+export function launchAgent(config: AgentConfigRow): Promise<void> {
+  return openInITerm(config);
 }
 
 export function autoLaunchAgents(): void {

--- a/hub/src/server.ts
+++ b/hub/src/server.ts
@@ -584,8 +584,12 @@ const handleAdminAgentStart: RouteHandler = async (req, res) => {
   if (!config) {
     return sendError(res, 404, "Agent config not found");
   }
-  launchAgent(config);
-  sendJson(res, 200, { ok: true });
+  try {
+    await launchAgent(config);
+    sendJson(res, 200, { ok: true });
+  } catch (e) {
+    sendError(res, 500, (e as Error).message);
+  }
 };
 
 const publicRoutes: Record<string, { method: string; handler: RouteHandler }> = {


### PR DESCRIPTION
## Summary
- Add "Agent Launcher" section to README.md documenting the feature, iTerm2 requirement, and usage steps
- Change `launchAgent` to return `Promise<void>` so osascript errors propagate
- Return HTTP 500 from `/admin-agent-start` when iTerm2 fails to open
- Dashboard already shows `alert(data.error)` on failure — now it actually receives the error

## Test plan
- [x] `npm run build` passes
- [x] `cd hub && npm test` — 104 tests pass
- [ ] Launch agent with iTerm2 installed — verify pane opens
- [ ] Launch agent without iTerm2 — verify error alert in dashboard

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)