### PR TITLE
Release v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## v1.6.0 (2026-03-09)
+
+### Features
+- Add client role (agent/bridge) for relay services (#96)
+- Add system notifications for bridge clients (#98)
+- Add agent launcher with iTerm2 integration and dashboard UI (#109)
+- Add launcher docs to README and handle missing iTerm2 gracefully (#115)
+
+### Fixes
+- Fix misleading trigger description in comparison table (#91)
+- Use @@ prefix for agent targeting in Slack bot (#103)
+- Show @@ prefix in agent reply display name (#105)
+- Show user-friendly error when port is already in use (#110)
+- Restore terminal to cooked mode on shutdown (#111)
+- Remove Claude-specific hints from agent launcher (#113)
+
+### Other
+- Add Slack bot integration section to README (#85)
+- Add Cursor Automations comparison to README (#87)
+- Move slack-bot to subsystems/ and co-launch with npm start (#94)
+- Document 'Always Show My Bot as Online' Slack setting (#100)
+
+
 ## v1.6.0 (2026-03-08)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -197,6 +197,24 @@ Open `http://localhost:9559` in your browser to:
 - Send messages and instructions to agents as the operator
 - Send images by pasting or dragging them into the message area (auto-resized to max 1024px)
 - Create and manage channels for scoped conversations
+- Launch and manage agents via the Agent Launcher (see below)
+
+### Agent Launcher
+
+The dashboard includes an **Agents** section for launching terminal panes from the browser. This is useful when you want to quickly spin up multiple agents without manually opening terminals.
+
+**Requirements**: [iTerm2](https://iterm2.com/) must be installed (macOS only). The launcher uses AppleScript to control iTerm2.
+
+**How it works**:
+
+1. Click **[+]** next to "Agents" in the dashboard sidebar
+2. Enter a name (e.g. `alice`) and working directory (e.g. `/path/to/project`)
+3. Click **Launch** — an iTerm2 pane opens, `cd`'d to the working directory, with the agent name as a badge
+4. Start your preferred tool (Claude Code, Cursor, etc.) in the opened terminal
+
+Multiple agents open as split panes in a single iTerm2 window. Enable **Auto-start** to launch agents automatically when the Hub starts.
+
+> **Note**: If iTerm2 is not installed, the Launch button will show an error message.
 
 ## 🔐 Authentication
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Agent A ──stdio──> MCP Server ──HTTP──> Hub ──HTTP──> MC
 (Claude Code, Cursor, etc.)             │             (Claude Code, Cursor, etc.)
                                         │
                                    Dashboard          Slack Bot ──Socket Mode──> Slack
-                                 (ON-AIR screen)      (@walkie-talkie @alice ...)
+                                 (ON-AIR screen)      (@walkie-talkie @@alice ...)
 ```
 
 ## 🤔 How is this different from multi-agent frameworks?
@@ -164,7 +164,7 @@ agent mcp enable walkie-talkie
 A Slack bot bridges your Slack workspace and the Hub. Mention the bot in Slack to talk to connected agents:
 
 ```
-@walkie-talkie @alice Please review the PR
+@walkie-talkie @@alice Please review the PR
 ```
 
 The bot replies in a thread, and you can continue the conversation there.

--- a/hub/src/__tests__/api-agent-launcher.test.ts
+++ b/hub/src/__tests__/api-agent-launcher.test.ts
@@ -1,0 +1,190 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startTestServer, stopTestServer, type TestContext } from "./helpers/server-harness.js";
+
+let ctx: TestContext;
+
+beforeAll(async () => {
+  ctx = await startTestServer();
+});
+
+afterAll(async () => {
+  await stopTestServer(ctx);
+});
+
+function adminHeaders(): Record<string, string> {
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${ctx.adminToken}`,
+  };
+}
+
+describe("Agent config CRUD API", () => {
+  let configId: string;
+
+  it("should create an agent config", async () => {
+    const res = await fetch(`${ctx.baseUrl}/admin-agent-config-create`, {
+      method: "POST",
+      headers: adminHeaders(),
+      body: JSON.stringify({ name: "test-agent", workDir: "/tmp" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; id: string };
+    expect(body.ok).toBe(true);
+    expect(body.id).toBeDefined();
+    configId = body.id;
+  });
+
+  it("should list agent configs", async () => {
+    const res = await fetch(`${ctx.baseUrl}/admin-agent-configs`, {
+      headers: { Authorization: `Bearer ${ctx.adminToken}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      configs: { id: string; name: string; workDir: string; command: string; autoStart: boolean; online: boolean }[];
+    };
+    expect(body.configs.length).toBeGreaterThanOrEqual(1);
+    const config = body.configs.find((c) => c.id === configId);
+    expect(config).toBeDefined();
+    expect(config!.name).toBe("test-agent");
+    expect(config!.workDir).toBe("/tmp");
+    expect(config!.autoStart).toBe(false);
+    expect(config!.online).toBe(false);
+  });
+
+  it("should reject creating a config with missing fields", async () => {
+    const res = await fetch(`${ctx.baseUrl}/admin-agent-config-create`, {
+      method: "POST",
+      headers: adminHeaders(),
+      body: JSON.stringify({ name: "bad" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("should reject invalid agent name", async () => {
+    for (const badName of ["has space", "has;semi", 'has"quote', "has$dollar"]) {
+      const res = await fetch(`${ctx.baseUrl}/admin-agent-config-create`, {
+        method: "POST",
+        headers: adminHeaders(),
+        body: JSON.stringify({ name: badName, workDir: "/tmp" }),
+      });
+      expect(res.status).toBe(400);
+    }
+  });
+
+  it("should reject duplicate agent name", async () => {
+    const res = await fetch(`${ctx.baseUrl}/admin-agent-config-create`, {
+      method: "POST",
+      headers: adminHeaders(),
+      body: JSON.stringify({ name: "test-agent", workDir: "/tmp" }),
+    });
+    expect(res.status).toBe(409);
+  });
+
+  it("should update an agent config", async () => {
+    const res = await fetch(`${ctx.baseUrl}/admin-agent-config-update`, {
+      method: "POST",
+      headers: adminHeaders(),
+      body: JSON.stringify({ id: configId, name: "test-agent-updated", autoStart: true }),
+    });
+    expect(res.status).toBe(200);
+
+    // Verify the update
+    const listRes = await fetch(`${ctx.baseUrl}/admin-agent-configs`, {
+      headers: { Authorization: `Bearer ${ctx.adminToken}` },
+    });
+    const body = (await listRes.json()) as {
+      configs: { id: string; name: string; autoStart: boolean }[];
+    };
+    const config = body.configs.find((c) => c.id === configId);
+    expect(config!.name).toBe("test-agent-updated");
+    expect(config!.autoStart).toBe(true);
+  });
+
+  it("should return 404 when updating non-existent config", async () => {
+    const res = await fetch(`${ctx.baseUrl}/admin-agent-config-update`, {
+      method: "POST",
+      headers: adminHeaders(),
+      body: JSON.stringify({ id: "non-existent-id", name: "nope" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("should delete an agent config", async () => {
+    const res = await fetch(`${ctx.baseUrl}/admin-agent-config-delete`, {
+      method: "POST",
+      headers: adminHeaders(),
+      body: JSON.stringify({ id: configId }),
+    });
+    expect(res.status).toBe(200);
+
+    // Verify deletion
+    const listRes = await fetch(`${ctx.baseUrl}/admin-agent-configs`, {
+      headers: { Authorization: `Bearer ${ctx.adminToken}` },
+    });
+    const body = (await listRes.json()) as { configs: { id: string }[] };
+    expect(body.configs.find((c) => c.id === configId)).toBeUndefined();
+  });
+
+  it("should return 404 when deleting non-existent config", async () => {
+    const res = await fetch(`${ctx.baseUrl}/admin-agent-config-delete`, {
+      method: "POST",
+      headers: adminHeaders(),
+      body: JSON.stringify({ id: "non-existent-id" }),
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("Agent launch API", () => {
+  it("should return 404 when launching non-existent config", async () => {
+    const res = await fetch(`${ctx.baseUrl}/admin-agent-start`, {
+      method: "POST",
+      headers: adminHeaders(),
+      body: JSON.stringify({ id: "non-existent" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("should return 200 when launching a valid config", async () => {
+    // Create a config
+    const createRes = await fetch(`${ctx.baseUrl}/admin-agent-config-create`, {
+      method: "POST",
+      headers: adminHeaders(),
+      body: JSON.stringify({ name: "launch-test", workDir: "/tmp" }),
+    });
+    const createBody = (await createRes.json()) as { id: string };
+
+    // Launch (will fail to open iTerm2 in test, but API returns 200)
+    const res = await fetch(`${ctx.baseUrl}/admin-agent-start`, {
+      method: "POST",
+      headers: adminHeaders(),
+      body: JSON.stringify({ id: createBody.id }),
+    });
+    expect(res.status).toBe(200);
+
+    // Clean up
+    await fetch(`${ctx.baseUrl}/admin-agent-config-delete`, {
+      method: "POST",
+      headers: adminHeaders(),
+      body: JSON.stringify({ id: createBody.id }),
+    });
+  });
+
+  it("should require admin auth for all agent endpoints", async () => {
+    const endpoints = [
+      { method: "GET", path: "/admin-agent-configs" },
+      { method: "POST", path: "/admin-agent-config-create" },
+      { method: "POST", path: "/admin-agent-config-update" },
+      { method: "POST", path: "/admin-agent-config-delete" },
+      { method: "POST", path: "/admin-agent-start" },
+    ];
+    for (const ep of endpoints) {
+      const res = await fetch(`${ctx.baseUrl}${ep.path}`, {
+        method: ep.method,
+        headers: { "Content-Type": "application/json" },
+        body: ep.method === "POST" ? JSON.stringify({}) : undefined,
+      });
+      expect(res.status).toBe(401);
+    }
+  });
+});

--- a/hub/src/__tests__/api-agent-launcher.test.ts
+++ b/hub/src/__tests__/api-agent-launcher.test.ts
@@ -4,8 +4,6 @@ import { startTestServer, stopTestServer, type TestContext } from "./helpers/ser
 vi.mock("../launcher.js", () => ({
   launchAgent: vi.fn(),
   autoLaunchAgents: vi.fn(),
-  resolveSkillHint: (name: string) => `/walkie-talkie:walkie-talkie ${name}`,
-  SKILL_HINT_TEMPLATE: "/walkie-talkie:walkie-talkie {{name}}",
 }));
 
 let ctx: TestContext;

--- a/hub/src/__tests__/api-agent-launcher.test.ts
+++ b/hub/src/__tests__/api-agent-launcher.test.ts
@@ -1,5 +1,12 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { startTestServer, stopTestServer, type TestContext } from "./helpers/server-harness.js";
+
+vi.mock("../launcher.js", () => ({
+  launchAgent: vi.fn(),
+  autoLaunchAgents: vi.fn(),
+  resolveSkillHint: (name: string) => `/walkie-talkie:walkie-talkie ${name}`,
+  SKILL_HINT_TEMPLATE: "/walkie-talkie:walkie-talkie {{name}}",
+}));
 
 let ctx: TestContext;
 

--- a/hub/src/__tests__/db.test.ts
+++ b/hub/src/__tests__/db.test.ts
@@ -1,19 +1,24 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   dbAddChannelMember,
+  dbCreateAgentConfig,
   dbCreateChannel,
+  dbDeleteAgentConfig,
   dbDeleteChannel,
   dbDeleteChannelMessages,
   dbDeleteReadCursorsForChannel,
+  dbGetAgentConfig,
   dbGetChannel,
   dbGetChannelMessages,
   dbGetRecentMessages,
   dbGetUnreadCounts,
   dbGetUserChannels,
+  dbListAgentConfigs,
   dbListChannels,
   dbRemoveAllMembersOfChannel,
   dbRemoveChannelMember,
   dbSaveMessage,
+  dbUpdateAgentConfig,
   dbUpdateReadCursor,
   initDB,
 } from "../db.js";
@@ -203,5 +208,51 @@ describe("read cursors", () => {
     });
     const counts = dbGetUnreadCounts("bob");
     expect(counts["#all"]).toBe(1);
+  });
+});
+
+describe("agent configs", () => {
+  it("should create and retrieve an agent config", () => {
+    const config = dbCreateAgentConfig("a1", "my-agent", "/tmp", "echo hi", false);
+    expect(config.id).toBe("a1");
+    expect(config.name).toBe("my-agent");
+    expect(config.work_dir).toBe("/tmp");
+    expect(config.command).toBe("echo hi");
+    expect(config.auto_start).toBe(0);
+
+    const retrieved = dbGetAgentConfig("a1");
+    expect(retrieved).toBeDefined();
+    expect(retrieved!.name).toBe("my-agent");
+  });
+
+  it("should list agent configs in creation order", () => {
+    dbCreateAgentConfig("b1", "agent-b", "/tmp", "echo b", false);
+    dbCreateAgentConfig("b2", "agent-c", "/tmp", "echo c", true);
+    const list = dbListAgentConfigs();
+    expect(list.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("should update an agent config", () => {
+    dbCreateAgentConfig("u1", "update-me", "/tmp", "echo old", false);
+    dbUpdateAgentConfig("u1", { name: "updated", command: "echo new", autoStart: true });
+    const config = dbGetAgentConfig("u1");
+    expect(config!.name).toBe("updated");
+    expect(config!.command).toBe("echo new");
+    expect(config!.auto_start).toBe(1);
+  });
+
+  it("should delete an agent config", () => {
+    dbCreateAgentConfig("d1", "delete-me", "/tmp", "echo del", false);
+    expect(dbDeleteAgentConfig("d1")).toBe(true);
+    expect(dbGetAgentConfig("d1")).toBeUndefined();
+  });
+
+  it("should return false when deleting non-existent config", () => {
+    expect(dbDeleteAgentConfig("nope")).toBe(false);
+  });
+
+  it("should enforce unique name constraint", () => {
+    dbCreateAgentConfig("n1", "unique-name", "/tmp", "echo 1", false);
+    expect(() => dbCreateAgentConfig("n2", "unique-name", "/tmp", "echo 2", false)).toThrow();
   });
 });

--- a/hub/src/dashboard.ts
+++ b/hub/src/dashboard.ts
@@ -925,9 +925,6 @@ export function getDashboardHTML(adminToken: string): string {
         <input type="text" id="agent-dialog-name" placeholder="alice" pattern="[a-zA-Z0-9_-]+">
         <span id="agent-dialog-name-error" style="color:var(--red);font-size:11px;display:none"></span>
       </label>
-      <label>Skill command <span style="font-weight:400;color:var(--text-tertiary)">(type this after claude starts)</span>
-        <code id="agent-dialog-command" style="font-family:var(--mono);font-size:12px;padding:8px 10px;background:var(--bg-base);color:var(--text-secondary);border:1px solid var(--border-subtle);border-radius:8px;word-break:break-all">/walkie-talkie:walkie-talkie ...</code>
-      </label>
       <label>Working Directory
         <input type="text" id="agent-dialog-workdir" placeholder="/path/to/project">
       </label>
@@ -1465,23 +1462,16 @@ export function getDashboardHTML(adminToken: string): string {
     const agentDialogName = document.getElementById("agent-dialog-name");
     const agentDialogNameError = document.getElementById("agent-dialog-name-error");
     const agentDialogWorkdir = document.getElementById("agent-dialog-workdir");
-    const agentDialogCommand = document.getElementById("agent-dialog-command");
     const agentDialogAutostart = document.getElementById("agent-dialog-autostart");
 
     function updateCommandPreview() {
       const name = agentDialogName.value.trim();
       if (name && AGENT_NAME_RE.test(name)) {
-        agentDialogCommand.textContent = '/walkie-talkie:walkie-talkie ' + name;
-        agentDialogCommand.style.color = "var(--text-secondary)";
         agentDialogNameError.style.display = "none";
       } else if (name) {
-        agentDialogCommand.textContent = '/walkie-talkie:walkie-talkie ...';
-        agentDialogCommand.style.color = "var(--text-tertiary)";
         agentDialogNameError.textContent = "Use only a-z, 0-9, hyphen, underscore";
         agentDialogNameError.style.display = "block";
       } else {
-        agentDialogCommand.textContent = '/walkie-talkie:walkie-talkie ...';
-        agentDialogCommand.style.color = "var(--text-tertiary)";
         agentDialogNameError.style.display = "none";
       }
     }

--- a/hub/src/dashboard.ts
+++ b/hub/src/dashboard.ts
@@ -366,6 +366,188 @@ export function getDashboardHTML(adminToken: string): string {
     transform: scale(0.98);
   }
 
+  /* Agent list */
+  #agent-list {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  #agent-list li {
+    padding: 7px 8px;
+    font-size: 14px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-radius: 8px;
+    transition: background 0.15s ease;
+  }
+  #agent-list li:hover {
+    background: var(--bg-hover);
+  }
+  .agent-info {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    min-width: 0;
+  }
+  .agent-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+  .agent-dot.online {
+    background: var(--green);
+    box-shadow: 0 0 8px rgba(52,211,153,0.35);
+  }
+  .agent-dot.offline {
+    background: #555;
+    box-shadow: none;
+  }
+  .agent-name {
+    font-weight: 500;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--text-primary);
+  }
+  .agent-actions {
+    display: flex;
+    gap: 4px;
+    flex-shrink: 0;
+  }
+  .agent-actions button {
+    background: transparent;
+    border: 1px solid var(--border);
+    color: var(--text-tertiary);
+    font-family: var(--mono);
+    font-size: 10px;
+    padding: 2px 8px;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    opacity: 0;
+  }
+  #agent-list li:hover .agent-actions button {
+    opacity: 1;
+  }
+  .agent-launch-btn:hover {
+    border-color: var(--green-border) !important;
+    color: var(--green) !important;
+    background: var(--green-soft) !important;
+  }
+  .agent-edit-btn:hover {
+    border-color: rgba(129,140,248,0.3) !important;
+    color: var(--accent) !important;
+    background: var(--accent-soft) !important;
+  }
+  .agent-del-btn:hover {
+    border-color: var(--red-border) !important;
+    color: var(--red) !important;
+    background: var(--red-soft) !important;
+  }
+
+  /* Agent dialog */
+  .dialog-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+  }
+  .dialog {
+    background: var(--bg-raised);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 24px;
+    width: 420px;
+    max-width: 90vw;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+  .dialog h2 {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0;
+  }
+  .dialog label {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-secondary);
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .dialog input, .dialog textarea {
+    font-family: var(--mono);
+    font-size: 13px;
+    padding: 8px 10px;
+    background: var(--bg-surface);
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    outline: none;
+    transition: border-color 0.15s ease;
+  }
+  .dialog input:focus, .dialog textarea:focus {
+    border-color: var(--accent);
+  }
+  .dialog input::placeholder, .dialog textarea::placeholder {
+    color: var(--text-tertiary);
+  }
+  .dialog textarea {
+    resize: vertical;
+    min-height: 60px;
+  }
+  .dialog .checkbox-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+    color: var(--text-secondary);
+  }
+  .dialog .checkbox-row input[type="checkbox"] {
+    width: 16px;
+    height: 16px;
+    accent-color: var(--accent);
+  }
+  .dialog .dialog-buttons {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+  .dialog .dialog-buttons button {
+    font-family: var(--font);
+    font-size: 13px;
+    font-weight: 500;
+    padding: 8px 16px;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+  }
+  .dialog .btn-cancel {
+    background: transparent;
+    color: var(--text-secondary);
+    border: 1px solid var(--border);
+  }
+  .dialog .btn-cancel:hover {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+  }
+  .dialog .btn-save {
+    background: var(--accent);
+    color: #fff;
+    border: 1px solid var(--accent);
+  }
+  .dialog .btn-save:hover {
+    opacity: 0.9;
+  }
+
   /* Messages */
   #messages {
     flex: 1;
@@ -714,6 +896,8 @@ export function getDashboardHTML(adminToken: string): string {
       <ul id="channel-list"></ul>
       <span class="sidebar-label">On Air</span>
       <ul id="user-list"></ul>
+      <span class="sidebar-label">Agents <button class="add-btn" id="add-agent-btn">+ New</button></span>
+      <ul id="agent-list"></ul>
       <button id="stop-all">Kick all agents</button>
     </div>
     <div class="message-area">
@@ -733,6 +917,30 @@ export function getDashboardHTML(adminToken: string): string {
       </div>
     </div>
   </div>
+  <div class="dialog-overlay" id="agent-dialog" style="display:none">
+    <div class="dialog">
+      <h2 id="agent-dialog-title">New Agent</h2>
+      <input type="hidden" id="agent-dialog-id">
+      <label>Name <span style="font-weight:400;color:var(--text-tertiary)">(a-z, 0-9, hyphen, underscore)</span>
+        <input type="text" id="agent-dialog-name" placeholder="alice" pattern="[a-zA-Z0-9_-]+">
+        <span id="agent-dialog-name-error" style="color:var(--red);font-size:11px;display:none"></span>
+      </label>
+      <label>Skill command <span style="font-weight:400;color:var(--text-tertiary)">(type this after claude starts)</span>
+        <code id="agent-dialog-command" style="font-family:var(--mono);font-size:12px;padding:8px 10px;background:var(--bg-base);color:var(--text-secondary);border:1px solid var(--border-subtle);border-radius:8px;word-break:break-all">/walkie-talkie:walkie-talkie ...</code>
+      </label>
+      <label>Working Directory
+        <input type="text" id="agent-dialog-workdir" placeholder="/path/to/project">
+      </label>
+      <div class="checkbox-row">
+        <input type="checkbox" id="agent-dialog-autostart">
+        <label for="agent-dialog-autostart" style="flex-direction:row;gap:0">Auto-start on Hub launch</label>
+      </div>
+      <div class="dialog-buttons">
+        <button class="btn-cancel" id="agent-dialog-cancel">Cancel</button>
+        <button class="btn-save" id="agent-dialog-save">Save</button>
+      </div>
+    </div>
+  </div>
   <script>
     const ADMIN_TOKEN = "${adminToken}";
     const adminHeaders = { "Content-Type": "application/json", "Authorization": "Bearer " + ADMIN_TOKEN };
@@ -745,6 +953,8 @@ export function getDashboardHTML(adminToken: string): string {
     const channels = new Map(); // name -> { memberCount, createdBy, members }
     const typingUsers = new Map(); // name -> { timeoutId, channel }
     const pendingReply = new Map(); // name -> timeoutId (30s no-TYPING → grey)
+    const agentConfigs = new Map(); // id -> { name, workDir, command, autoStart, status, pid, exitCode }
+    const agentListEl = document.getElementById("agent-list");
 
     let selectedChannel = "#all";
     const unreadCounts = {}; // channel -> count
@@ -806,6 +1016,71 @@ export function getDashboardHTML(adminToken: string): string {
         if (!users.has(targetName)) setRecipient("@all");
       }
       updateChannelHeader();
+    }
+
+    function renderAgents() {
+      agentListEl.innerHTML = "";
+      for (const [id, agent] of agentConfigs) {
+        const li = document.createElement("li");
+        const info = document.createElement("span");
+        info.className = "agent-info";
+        const isOnline = users.has(agent.name) && users.get(agent.name);
+        info.innerHTML = '<span class="agent-dot ' + (isOnline ? 'online' : 'offline') + '"></span><span class="agent-name">' + agent.name + '</span>';
+        const actions = document.createElement("span");
+        actions.className = "agent-actions";
+        const launchBtn = document.createElement("button");
+        launchBtn.className = "agent-launch-btn";
+        launchBtn.textContent = "launch";
+        launchBtn.onclick = (e) => { e.stopPropagation(); agentLaunch(id); };
+        actions.appendChild(launchBtn);
+        if (!isOnline) {
+          const editBtn = document.createElement("button");
+          editBtn.className = "agent-edit-btn";
+          editBtn.textContent = "edit";
+          editBtn.onclick = (e) => { e.stopPropagation(); openAgentDialog(id, agent); };
+          actions.appendChild(editBtn);
+          const delBtn = document.createElement("button");
+          delBtn.className = "agent-del-btn";
+          delBtn.textContent = "x";
+          delBtn.onclick = (e) => { e.stopPropagation(); if (confirm("Delete agent config '" + agent.name + "'?")) agentDelete(id); };
+          actions.appendChild(delBtn);
+        }
+        li.appendChild(info);
+        li.appendChild(actions);
+        agentListEl.appendChild(li);
+      }
+    }
+
+    function agentLaunch(id) {
+      fetch("/admin-agent-start", {
+        method: "POST",
+        headers: adminHeaders,
+        body: JSON.stringify({ id }),
+      }).then(r => r.json()).then(data => {
+        if (data.error) alert(data.error);
+      }).catch(() => {});
+    }
+
+    function agentDelete(id) {
+      fetch("/admin-agent-config-delete", {
+        method: "POST",
+        headers: adminHeaders,
+        body: JSON.stringify({ id }),
+      }).then(r => r.json()).then(data => {
+        if (data.error) alert(data.error);
+      }).catch(() => {});
+    }
+
+    function refreshAgentConfigs() {
+      fetch("/admin-agent-configs", { headers: { "Authorization": "Bearer " + ADMIN_TOKEN } })
+        .then(r => r.json())
+        .then(data => {
+          agentConfigs.clear();
+          for (const c of data.configs) {
+            agentConfigs.set(c.id, { name: c.name, workDir: c.workDir, autoStart: c.autoStart });
+          }
+          renderAgents();
+        }).catch(() => {});
     }
 
     function refreshChannels() {
@@ -1183,7 +1458,85 @@ export function getDashboardHTML(adminToken: string): string {
       messagesEl.innerHTML = '<div class="empty">Waiting for transmissions...</div>';
     };
 
-    // Add channel button
+    const AGENT_NAME_RE = /^[a-zA-Z0-9_-]+$/;
+    const agentDialogEl = document.getElementById("agent-dialog");
+    const agentDialogTitle = document.getElementById("agent-dialog-title");
+    const agentDialogId = document.getElementById("agent-dialog-id");
+    const agentDialogName = document.getElementById("agent-dialog-name");
+    const agentDialogNameError = document.getElementById("agent-dialog-name-error");
+    const agentDialogWorkdir = document.getElementById("agent-dialog-workdir");
+    const agentDialogCommand = document.getElementById("agent-dialog-command");
+    const agentDialogAutostart = document.getElementById("agent-dialog-autostart");
+
+    function updateCommandPreview() {
+      const name = agentDialogName.value.trim();
+      if (name && AGENT_NAME_RE.test(name)) {
+        agentDialogCommand.textContent = '/walkie-talkie:walkie-talkie ' + name;
+        agentDialogCommand.style.color = "var(--text-secondary)";
+        agentDialogNameError.style.display = "none";
+      } else if (name) {
+        agentDialogCommand.textContent = '/walkie-talkie:walkie-talkie ...';
+        agentDialogCommand.style.color = "var(--text-tertiary)";
+        agentDialogNameError.textContent = "Use only a-z, 0-9, hyphen, underscore";
+        agentDialogNameError.style.display = "block";
+      } else {
+        agentDialogCommand.textContent = '/walkie-talkie:walkie-talkie ...';
+        agentDialogCommand.style.color = "var(--text-tertiary)";
+        agentDialogNameError.style.display = "none";
+      }
+    }
+
+    agentDialogName.addEventListener("input", updateCommandPreview);
+
+    function openAgentDialog(id, agent) {
+      const isEdit = !!id;
+      agentDialogTitle.textContent = isEdit ? "Edit Agent" : "New Agent";
+      agentDialogId.value = id || "";
+      agentDialogName.value = agent ? agent.name : "";
+      agentDialogWorkdir.value = agent ? agent.workDir : "";
+      agentDialogAutostart.checked = agent ? agent.autoStart : false;
+      updateCommandPreview();
+      agentDialogEl.style.display = "flex";
+      agentDialogName.focus();
+    }
+
+    function closeAgentDialog() {
+      agentDialogEl.style.display = "none";
+    }
+
+    document.getElementById("agent-dialog-cancel").onclick = closeAgentDialog;
+    agentDialogEl.onclick = (e) => { if (e.target === agentDialogEl) closeAgentDialog(); };
+
+    document.getElementById("agent-dialog-save").onclick = () => {
+      const id = agentDialogId.value;
+      const name = agentDialogName.value.trim();
+      const workDir = agentDialogWorkdir.value.trim();
+      const autoStart = agentDialogAutostart.checked;
+      if (!name || !AGENT_NAME_RE.test(name)) { agentDialogName.focus(); updateCommandPreview(); return; }
+      if (!workDir) { agentDialogWorkdir.focus(); return; }
+      if (id) {
+        fetch("/admin-agent-config-update", {
+          method: "POST",
+          headers: adminHeaders,
+          body: JSON.stringify({ id, name, workDir, autoStart }),
+        }).then(r => r.json()).then(data => {
+          if (data.error) alert(data.error);
+          else closeAgentDialog();
+        }).catch(() => {});
+      } else {
+        fetch("/admin-agent-config-create", {
+          method: "POST",
+          headers: adminHeaders,
+          body: JSON.stringify({ name, workDir }),
+        }).then(r => r.json()).then(data => {
+          if (data.error) alert(data.error);
+          else closeAgentDialog();
+        }).catch(() => {});
+      }
+    };
+
+    document.getElementById("add-agent-btn").onclick = () => openAgentDialog(null, null);
+
     document.getElementById("add-channel-btn").onclick = () => {
       const name = prompt("Channel name (without #):");
       if (!name || !name.trim()) return;
@@ -1219,6 +1572,9 @@ export function getDashboardHTML(adminToken: string): string {
       renderChannels();
       updateChannelHeader();
     }).catch(() => {});
+
+    // Load agent configs
+    refreshAgentConfigs();
 
     // Load unread counts
     fetch("/admin-unread-counts", { headers: { "Authorization": "Bearer " + ADMIN_TOKEN } })
@@ -1266,10 +1622,12 @@ export function getDashboardHTML(adminToken: string): string {
         if (users.has(ev.name)) {
           users.set(ev.name, ev.online);
           renderUsers();
+          renderAgents();
         }
       } else if (ev.type === "join") {
         users.set(ev.name, true);
         renderUsers();
+        renderAgents();
         refreshChannels();
         addMessage(
           '<span class="time">' + formatTime(ev.timestamp) + '</span>' +
@@ -1280,6 +1638,7 @@ export function getDashboardHTML(adminToken: string): string {
       } else if (ev.type === "leave") {
         users.delete(ev.name);
         renderUsers();
+        renderAgents();
         refreshChannels();
         addMessage(
           '<span class="time">' + formatTime(ev.timestamp) + '</span>' +
@@ -1352,6 +1711,11 @@ export function getDashboardHTML(adminToken: string): string {
           "system channel-event leave",
           null
         );
+      } else if (ev.type === "agent_config_create" || ev.type === "agent_config_update") {
+        refreshAgentConfigs();
+      } else if (ev.type === "agent_config_delete") {
+        agentConfigs.delete(ev.id);
+        renderAgents();
       } else if (ev.type === "typing") {
         clearPendingReply(ev.name);
         if (users.has(ev.name)) users.set(ev.name, true);

--- a/hub/src/db.ts
+++ b/hub/src/db.ts
@@ -3,6 +3,16 @@ import Database from "better-sqlite3";
 
 import type { Message, MessageImage } from "./types.js";
 
+export interface AgentConfigRow {
+  id: string;
+  name: string;
+  work_dir: string;
+  command: string;
+  auto_start: number;
+  env_vars: string | null;
+  created_at: number;
+}
+
 export interface ChannelRow {
   name: string;
   created_by: string;
@@ -56,6 +66,24 @@ export function initDB(): void {
       PRIMARY KEY (user_name, channel)
     )
   `);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS agent_configs (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL UNIQUE,
+      work_dir TEXT NOT NULL,
+      command TEXT NOT NULL DEFAULT '',
+      auto_start INTEGER NOT NULL DEFAULT 0,
+      env_vars TEXT,
+      created_at INTEGER NOT NULL
+    )
+  `);
+
+  try {
+    db.exec("ALTER TABLE agent_configs ADD COLUMN env_vars TEXT");
+  } catch {
+    /* column already exists */
+  }
 
   try {
     db.exec("ALTER TABLE messages ADD COLUMN image TEXT");
@@ -194,6 +222,74 @@ export function dbGetUnreadCounts(userName: string): Record<string, number> {
 
 export function dbDeleteReadCursorsForChannel(channel: string): void {
   db.prepare("DELETE FROM read_cursors WHERE channel = ?").run(channel);
+}
+
+// Agent config CRUD
+export function dbCreateAgentConfig(
+  id: string,
+  name: string,
+  workDir: string,
+  command: string,
+  autoStart: boolean,
+  envVars?: Record<string, string>,
+): AgentConfigRow {
+  const now = Date.now();
+  const envJson = envVars ? JSON.stringify(envVars) : null;
+  db.prepare(
+    "INSERT INTO agent_configs (id, name, work_dir, command, auto_start, env_vars, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+  ).run(id, name, workDir, command, autoStart ? 1 : 0, envJson, now);
+  return { id, name, work_dir: workDir, command, auto_start: autoStart ? 1 : 0, env_vars: envJson, created_at: now };
+}
+
+export function dbListAgentConfigs(): AgentConfigRow[] {
+  return db.prepare("SELECT * FROM agent_configs ORDER BY created_at").all() as AgentConfigRow[];
+}
+
+export function dbGetAgentConfig(id: string): AgentConfigRow | undefined {
+  return db.prepare("SELECT * FROM agent_configs WHERE id = ?").get(id) as AgentConfigRow | undefined;
+}
+
+export function dbUpdateAgentConfig(
+  id: string,
+  updates: {
+    name?: string;
+    workDir?: string;
+    command?: string;
+    autoStart?: boolean;
+    envVars?: Record<string, string> | null;
+  },
+): boolean {
+  const fields: string[] = [];
+  const values: unknown[] = [];
+  if (updates.name !== undefined) {
+    fields.push("name = ?");
+    values.push(updates.name);
+  }
+  if (updates.workDir !== undefined) {
+    fields.push("work_dir = ?");
+    values.push(updates.workDir);
+  }
+  if (updates.command !== undefined) {
+    fields.push("command = ?");
+    values.push(updates.command);
+  }
+  if (updates.autoStart !== undefined) {
+    fields.push("auto_start = ?");
+    values.push(updates.autoStart ? 1 : 0);
+  }
+  if (updates.envVars !== undefined) {
+    fields.push("env_vars = ?");
+    values.push(updates.envVars ? JSON.stringify(updates.envVars) : null);
+  }
+  if (fields.length === 0) return false;
+  values.push(id);
+  const result = db.prepare(`UPDATE agent_configs SET ${fields.join(", ")} WHERE id = ?`).run(...values);
+  return result.changes > 0;
+}
+
+export function dbDeleteAgentConfig(id: string): boolean {
+  const result = db.prepare("DELETE FROM agent_configs WHERE id = ?").run(id);
+  return result.changes > 0;
 }
 
 function dbPruneAllChannel(): void {

--- a/hub/src/events.ts
+++ b/hub/src/events.ts
@@ -18,7 +18,10 @@ export type HubEvent =
   | { type: "channel_delete"; name: string; timestamp: number }
   | { type: "status"; name: string; online: boolean; timestamp: number }
   | { type: "typing"; name: string; channel: string; timestamp: number }
-  | { type: "read_update"; userName: string; channel: string; timestamp: number };
+  | { type: "read_update"; userName: string; channel: string; timestamp: number }
+  | { type: "agent_config_create"; id: string; name: string; timestamp: number }
+  | { type: "agent_config_update"; id: string; name: string; timestamp: number }
+  | { type: "agent_config_delete"; id: string; timestamp: number };
 
 const HEARTBEAT_INTERVAL_MS = 30_000; // 30 seconds
 
@@ -54,6 +57,17 @@ export function addSSEClient(res: ServerResponse): void {
     clients.delete(res);
     stopHeartbeat();
   });
+}
+
+export function closeAllSSEClients(): void {
+  if (heartbeatTimer) {
+    clearInterval(heartbeatTimer);
+    heartbeatTimer = null;
+  }
+  for (const client of clients) {
+    client.end();
+  }
+  clients.clear();
 }
 
 export function broadcast(event: HubEvent): void {

--- a/hub/src/index.ts
+++ b/hub/src/index.ts
@@ -1,3 +1,4 @@
+import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { getRegisteredUsers } from "./auth.js";
 import { initGeneralChannel } from "./channels.js";
@@ -27,8 +28,11 @@ initGeneralChannel();
 
 const server = createHubServer(port, adminToken, joinToken);
 
-// Auto-launch agents only after the server is actually listening
+// After the server is listening, open the dashboard and auto-launch agents
 server.on("listening", () => {
+  execFile("open", [`http://localhost:${port}`], (err) => {
+    if (err) console.error(`[open] Failed to open browser: ${err.message}`);
+  });
   autoLaunchAgents();
 });
 

--- a/hub/src/index.ts
+++ b/hub/src/index.ts
@@ -1,5 +1,11 @@
+import { randomUUID } from "node:crypto";
+import { getRegisteredUsers } from "./auth.js";
 import { initGeneralChannel } from "./channels.js";
 import { initDB } from "./db.js";
+import { closeAllSSEClients } from "./events.js";
+import { autoLaunchAgents } from "./launcher.js";
+import { closeAllPolls } from "./polling.js";
+import { enqueueAndDeliver, ensureQueue } from "./router.js";
 import { createHubServer } from "./server.js";
 
 const port = parseInt(process.env.PORT ?? "9559", 10);
@@ -19,4 +25,41 @@ if (!adminToken) {
 initDB();
 initGeneralChannel();
 
-createHubServer(port, adminToken, joinToken);
+const server = createHubServer(port, adminToken, joinToken);
+
+// Auto-launch agents with autoStart=true
+autoLaunchAgents();
+
+// Graceful shutdown
+let shuttingDown = false;
+function handleShutdown(): void {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.log("\n[shutdown] Notifying connected users...");
+  // Send RADIO_KILLED to all connected users so they disconnect gracefully
+  for (const name of getRegisteredUsers()) {
+    ensureQueue(name);
+    enqueueAndDeliver(name, {
+      id: randomUUID(),
+      from: "system",
+      to: name,
+      content: "RADIO_KILLED: Hub is shutting down.",
+      channel: "#all",
+      timestamp: Date.now(),
+    });
+  }
+  closeAllSSEClients();
+  closeAllPolls();
+  server.close(() => {
+    console.log("[shutdown] Hub stopped.");
+    process.exit(0);
+  });
+  // Force exit after 10 seconds
+  setTimeout(() => {
+    console.error("[shutdown] Force exit after timeout");
+    process.exit(1);
+  }, 10_000).unref();
+}
+
+process.on("SIGINT", handleShutdown);
+process.on("SIGTERM", handleShutdown);

--- a/hub/src/index.ts
+++ b/hub/src/index.ts
@@ -37,6 +37,10 @@ let shuttingDown = false;
 function handleShutdown(): void {
   if (shuttingDown) return;
   shuttingDown = true;
+  // Restore terminal to cooked mode if it was set to raw
+  if (process.stdin.isTTY && process.stdin.isRaw) {
+    process.stdin.setRawMode(false);
+  }
   console.log("\n[shutdown] Notifying connected users...");
   // Send RADIO_KILLED to all connected users so they disconnect gracefully
   for (const name of getRegisteredUsers()) {

--- a/hub/src/index.ts
+++ b/hub/src/index.ts
@@ -27,8 +27,10 @@ initGeneralChannel();
 
 const server = createHubServer(port, adminToken, joinToken);
 
-// Auto-launch agents with autoStart=true
-autoLaunchAgents();
+// Auto-launch agents only after the server is actually listening
+server.on("listening", () => {
+  autoLaunchAgents();
+});
 
 // Graceful shutdown
 let shuttingDown = false;

--- a/hub/src/launcher.ts
+++ b/hub/src/launcher.ts
@@ -5,13 +5,7 @@ import { join } from "node:path";
 import type { AgentConfigRow } from "./db.js";
 import { dbListAgentConfigs } from "./db.js";
 
-export const SKILL_HINT_TEMPLATE = "/walkie-talkie:walkie-talkie {{name}}";
-
 let windowOpened = false;
-
-export function resolveSkillHint(name: string): string {
-  return SKILL_HINT_TEMPLATE.replace(/\{\{name\}\}/g, name);
-}
 
 function escapeAppleScript(s: string): string {
   return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
@@ -22,14 +16,12 @@ function shellQuote(s: string): string {
 }
 
 function createLaunchScript(config: AgentConfigRow): string {
-  const hint = resolveSkillHint(config.name);
   const nameBase64 = Buffer.from(config.name).toString("base64");
   const scriptPath = join(tmpdir(), `wt-launch-${config.name}-${Date.now()}.sh`);
   const script = `#!/bin/zsh
 cd ${shellQuote(config.work_dir)}
 rm -f "$0"
 printf '\\033]1337;SetBadgeFormat=${nameBase64}\\007'
-printf '\\033c>>> Run: claude\\n>>> Then type: ${hint}\\n'
 exec $SHELL
 `;
   writeFileSync(scriptPath, script, { mode: 0o755 });

--- a/hub/src/launcher.ts
+++ b/hub/src/launcher.ts
@@ -46,21 +46,22 @@ function openInITerm(config: AgentConfigRow): Promise<void> {
         "\n",
       );
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     execFile("osascript", ["-e", script], (err) => {
       if (err) {
         console.error(`[launcher] Failed to open iTerm2 for ${config.name}: ${err.message}`);
+        reject(new Error(`Failed to open iTerm2: ${err.message}`));
       } else {
-        console.log(`[launcher] Opened iTerm2 ${windowOpened ? "tab" : "window"} for ${config.name}`);
+        console.log(`[launcher] Opened iTerm2 ${windowOpened ? "pane" : "window"} for ${config.name}`);
         windowOpened = true;
+        resolve();
       }
-      resolve();
     });
   });
 }
 
-export function launchAgent(config: AgentConfigRow): void {
-  openInITerm(config);
+export function launchAgent(config: AgentConfigRow): Promise<void> {
+  return openInITerm(config);
 }
 
 export function autoLaunchAgents(): void {

--- a/hub/src/launcher.ts
+++ b/hub/src/launcher.ts
@@ -50,11 +50,9 @@ function openInITerm(config: AgentConfigRow): Promise<void> {
         "  end tell",
         "end tell",
       ].join("\n")
-    : [
-        'tell application "iTerm2"',
-        `  create window with default profile command "${escapedPath}"`,
-        "end tell",
-      ].join("\n");
+    : ['tell application "iTerm2"', `  create window with default profile command "${escapedPath}"`, "end tell"].join(
+        "\n",
+      );
 
   return new Promise((resolve) => {
     execFile("osascript", ["-e", script], (err) => {

--- a/hub/src/launcher.ts
+++ b/hub/src/launcher.ts
@@ -1,0 +1,87 @@
+import { execFile } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentConfigRow } from "./db.js";
+import { dbListAgentConfigs } from "./db.js";
+
+export const SKILL_HINT_TEMPLATE = "/walkie-talkie:walkie-talkie {{name}}";
+
+let windowOpened = false;
+
+export function resolveSkillHint(name: string): string {
+  return SKILL_HINT_TEMPLATE.replace(/\{\{name\}\}/g, name);
+}
+
+function escapeAppleScript(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function shellQuote(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+function createLaunchScript(config: AgentConfigRow): string {
+  const hint = resolveSkillHint(config.name);
+  const nameBase64 = Buffer.from(config.name).toString("base64");
+  const scriptPath = join(tmpdir(), `wt-launch-${config.name}-${Date.now()}.sh`);
+  const script = `#!/bin/zsh
+cd ${shellQuote(config.work_dir)}
+rm -f "$0"
+printf '\\033]1337;SetBadgeFormat=${nameBase64}\\007'
+printf '\\033c>>> Run: claude\\n>>> Then type: ${hint}\\n'
+exec $SHELL
+`;
+  writeFileSync(scriptPath, script, { mode: 0o755 });
+  return scriptPath;
+}
+
+function openInITerm(config: AgentConfigRow): Promise<void> {
+  const scriptPath = createLaunchScript(config);
+  const escapedPath = escapeAppleScript(scriptPath);
+
+  const script = windowOpened
+    ? [
+        'tell application "iTerm2"',
+        "  tell current window",
+        "    tell current session of current tab",
+        `      set newSession to (split vertically with default profile command "${escapedPath}")`,
+        "    end tell",
+        "  end tell",
+        "end tell",
+      ].join("\n")
+    : [
+        'tell application "iTerm2"',
+        `  create window with default profile command "${escapedPath}"`,
+        "end tell",
+      ].join("\n");
+
+  return new Promise((resolve) => {
+    execFile("osascript", ["-e", script], (err) => {
+      if (err) {
+        console.error(`[launcher] Failed to open iTerm2 for ${config.name}: ${err.message}`);
+      } else {
+        console.log(`[launcher] Opened iTerm2 ${windowOpened ? "tab" : "window"} for ${config.name}`);
+        windowOpened = true;
+      }
+      resolve();
+    });
+  });
+}
+
+export function launchAgent(config: AgentConfigRow): void {
+  openInITerm(config);
+}
+
+export function autoLaunchAgents(): void {
+  const configs = dbListAgentConfigs().filter((c) => c.auto_start);
+  if (configs.length === 0) return;
+
+  let chain = Promise.resolve();
+  for (const config of configs) {
+    chain = chain.then(() => {
+      console.log(`[auto-launch] ${config.name}`);
+      return openInITerm(config);
+    });
+  }
+}

--- a/hub/src/polling.ts
+++ b/hub/src/polling.ts
@@ -84,6 +84,17 @@ export function deliverMessage(userName: string): void {
   poll.res.end(JSON.stringify({ messages }));
 }
 
+export function closeAllPolls(): void {
+  for (const [, poll] of pendingPolls) {
+    clearTimeout(poll.timer);
+    if (!poll.res.writableEnded) {
+      poll.res.writeHead(204);
+      poll.res.end();
+    }
+  }
+  pendingPolls.clear();
+}
+
 export function removePoll(userName: string): void {
   const poll = pendingPolls.get(userName);
   if (poll) {

--- a/hub/src/server.ts
+++ b/hub/src/server.ts
@@ -584,8 +584,12 @@ const handleAdminAgentStart: RouteHandler = async (req, res) => {
   if (!config) {
     return sendError(res, 404, "Agent config not found");
   }
-  launchAgent(config);
-  sendJson(res, 200, { ok: true });
+  try {
+    await launchAgent(config);
+    sendJson(res, 200, { ok: true });
+  } catch (e) {
+    sendError(res, 500, (e as Error).message);
+  }
 };
 
 const publicRoutes: Record<string, { method: string; handler: RouteHandler }> = {

--- a/hub/src/server.ts
+++ b/hub/src/server.ts
@@ -20,22 +20,30 @@ import {
 } from "./channels.js";
 import { getDashboardHTML } from "./dashboard.js";
 import {
+  dbCreateAgentConfig,
   dbCreateChannel,
+  dbDeleteAgentConfig,
   dbDeleteChannel,
   dbDeleteChannelMessages,
   dbDeleteReadCursorsForChannel,
+  dbGetAgentConfig,
   dbGetChannel,
   dbGetChannelMessages,
   dbGetRecentMessages,
   dbGetUnreadCounts,
   dbGetUserChannels,
+  dbListAgentConfigs,
   dbListChannels,
+  dbUpdateAgentConfig,
   dbUpdateReadCursor,
 } from "./db.js";
 import { addSSEClient, broadcast } from "./events.js";
+import { launchAgent } from "./launcher.js";
 import { addPoll, isOnline, onPollDisconnect, removePoll, setOffline, setOnline } from "./polling.js";
 import { drainQueue, enqueueAndDeliver, ensureQueue, notifyBridges, removeQueue, routeMessage } from "./router.js";
 import type { RegisterRequest, RouteHandler, SendRequest } from "./types.js";
+
+const AGENT_NAME_RE = /^[a-zA-Z0-9_-]+$/;
 
 function readBody(req: IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -463,6 +471,123 @@ const handleAdminUnreadCounts: RouteHandler = async (_req, res) => {
   sendJson(res, 200, { counts });
 };
 
+// Agent config endpoints
+const handleAdminAgentConfigs: RouteHandler = async (_req, res) => {
+  const configs = dbListAgentConfigs();
+  const result = configs.map((c) => ({
+    id: c.id,
+    name: c.name,
+    workDir: c.work_dir,
+    command: c.command,
+    autoStart: c.auto_start === 1,
+    envVars: c.env_vars ? JSON.parse(c.env_vars) : {},
+    createdAt: c.created_at,
+    online: isUserRegistered(c.name) && isOnline(c.name),
+  }));
+  sendJson(res, 200, { configs: result });
+};
+
+const handleAdminAgentConfigCreate: RouteHandler = async (req, res) => {
+  const body = JSON.parse(await readBody(req)) as {
+    name?: string;
+    workDir?: string;
+    command?: string;
+    autoStart?: boolean;
+    envVars?: Record<string, string>;
+  };
+  if (!body.name || typeof body.name !== "string") {
+    return sendError(res, 400, "Missing or invalid 'name' field");
+  }
+  if (!AGENT_NAME_RE.test(body.name)) {
+    return sendError(res, 400, "Agent name must contain only a-z, 0-9, hyphen, underscore");
+  }
+  if (!body.workDir || typeof body.workDir !== "string") {
+    return sendError(res, 400, "Missing or invalid 'workDir' field");
+  }
+  try {
+    const id = randomUUID();
+    const config = dbCreateAgentConfig(
+      id,
+      body.name,
+      body.workDir,
+      body.command || "",
+      body.autoStart ?? false,
+      body.envVars,
+    );
+    broadcast({ type: "agent_config_create", id: config.id, name: config.name, timestamp: Date.now() });
+    console.log(`[agent-config-create] ${config.name}`);
+    sendJson(res, 200, { ok: true, id: config.id });
+  } catch (e) {
+    sendError(res, 409, (e as Error).message);
+  }
+};
+
+const handleAdminAgentConfigUpdate: RouteHandler = async (req, res) => {
+  const body = JSON.parse(await readBody(req)) as {
+    id?: string;
+    name?: string;
+    workDir?: string;
+    autoStart?: boolean;
+    envVars?: Record<string, string> | null;
+  };
+  if (!body.id || typeof body.id !== "string") {
+    return sendError(res, 400, "Missing or invalid 'id' field");
+  }
+  if (body.name && !AGENT_NAME_RE.test(body.name)) {
+    return sendError(res, 400, "Agent name must contain only a-z, 0-9, hyphen, underscore");
+  }
+  const config = dbGetAgentConfig(body.id);
+  if (!config) {
+    return sendError(res, 404, "Agent config not found");
+  }
+  if (isUserRegistered(config.name)) {
+    return sendError(res, 409, "Agent is currently online. Kick it first.");
+  }
+  dbUpdateAgentConfig(body.id, {
+    name: body.name,
+    workDir: body.workDir,
+    autoStart: body.autoStart,
+    envVars: body.envVars,
+  });
+  const name = body.name ?? config.name;
+  broadcast({ type: "agent_config_update", id: body.id, name, timestamp: Date.now() });
+  console.log(`[agent-config-update] ${name}`);
+  sendJson(res, 200, { ok: true });
+};
+
+const handleAdminAgentConfigDelete: RouteHandler = async (req, res) => {
+  const body = JSON.parse(await readBody(req)) as { id?: string };
+  if (!body.id || typeof body.id !== "string") {
+    return sendError(res, 400, "Missing or invalid 'id' field");
+  }
+  const configToDelete = dbGetAgentConfig(body.id);
+  if (!configToDelete) {
+    return sendError(res, 404, "Agent config not found");
+  }
+  if (isUserRegistered(configToDelete.name)) {
+    return sendError(res, 409, "Agent is currently online. Kick it first.");
+  }
+  if (!dbDeleteAgentConfig(body.id)) {
+    return sendError(res, 404, "Agent config not found");
+  }
+  broadcast({ type: "agent_config_delete", id: body.id, timestamp: Date.now() });
+  console.log(`[agent-config-delete] ${body.id}`);
+  sendJson(res, 200, { ok: true });
+};
+
+const handleAdminAgentStart: RouteHandler = async (req, res) => {
+  const body = JSON.parse(await readBody(req)) as { id?: string };
+  if (!body.id || typeof body.id !== "string") {
+    return sendError(res, 400, "Missing or invalid 'id' field");
+  }
+  const config = dbGetAgentConfig(body.id);
+  if (!config) {
+    return sendError(res, 404, "Agent config not found");
+  }
+  launchAgent(config);
+  sendJson(res, 200, { ok: true });
+};
+
 const publicRoutes: Record<string, { method: string; handler: RouteHandler }> = {
   "/users": { method: "GET", handler: handleUsers },
   "/channels": { method: "GET", handler: handleListChannels },
@@ -481,6 +606,11 @@ const adminRoutes: Record<string, { method: string; handler: RouteHandler }> = {
   "/admin-channel-history": { method: "GET", handler: handleAdminChannelHistory },
   "/admin-mark-read": { method: "POST", handler: handleAdminMarkRead },
   "/admin-unread-counts": { method: "GET", handler: handleAdminUnreadCounts },
+  "/admin-agent-configs": { method: "GET", handler: handleAdminAgentConfigs },
+  "/admin-agent-config-create": { method: "POST", handler: handleAdminAgentConfigCreate },
+  "/admin-agent-config-update": { method: "POST", handler: handleAdminAgentConfigUpdate },
+  "/admin-agent-config-delete": { method: "POST", handler: handleAdminAgentConfigDelete },
+  "/admin-agent-start": { method: "POST", handler: handleAdminAgentStart },
 };
 
 const protectedRoutes: Record<string, { method: string; handler: RouteHandler }> = {

--- a/hub/src/server.ts
+++ b/hub/src/server.ts
@@ -756,6 +756,13 @@ export function createHubServer(port: number, adminToken: string, joinToken: str
   }
 
   const server = createServer(handleRequest);
+  server.on("error", (err: NodeJS.ErrnoException) => {
+    if (err.code === "EADDRINUSE") {
+      console.error(`Error: Port ${port} is already in use. Is another Hub instance running?`);
+      process.exit(1);
+    }
+    throw err;
+  });
   server.listen(port, "127.0.0.1", () => {
     console.log(`Walkie-Talkie Hub listening on http://localhost:${port}`);
   });

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "npm run build --workspaces",
     "clean": "npm run clean --workspaces",
-    "start": "npm start --workspace=hub & if [ -n \"$WALKIE_TALKIE_SLACK_BOT_TOKEN\" ]; then npm start --workspace=@walkie-talkie/slack-bot & fi; wait",
+    "start": "npm start --workspace=hub & HUB_PID=$!; sleep 1; if ! kill -0 $HUB_PID 2>/dev/null; then wait $HUB_PID; exit $?; fi; if [ -n \"$WALKIE_TALKIE_SLACK_BOT_TOKEN\" ]; then npm start --workspace=@walkie-talkie/slack-bot & fi; wait",
     "bundle": "node scripts/bundle.mjs",
     "test": "npm run test --workspaces --if-present",
     "lint": "biome lint .",

--- a/subsystems/slack-bot/README.md
+++ b/subsystems/slack-bot/README.md
@@ -3,7 +3,7 @@
 A Slack bot that bridges Slack and the Walkie-Talkie Hub. Users can mention the bot in Slack to send messages to AI agents connected to the Hub.
 
 ```
-Slack (@walkie-talkie @alice do something)
+Slack (@walkie-talkie @@alice do something)
   ↓
 slack-bot (Socket Mode) ──HTTP──> Hub ──> Claude Code (alice)
   ↑                                           │
@@ -105,7 +105,7 @@ The bot also appears on the Hub dashboard as `slack`.
 In any Slack channel where the bot is invited:
 
 ```
-@walkie-talkie @alice Please review the PR       → sends to agent "alice"
+@walkie-talkie @@alice Please review the PR       → sends to agent "alice"
 @walkie-talkie What is the project status?        → sends to @all (all connected agents)
 ```
 
@@ -115,7 +115,7 @@ The bot will:
 2. Forward the message to the Hub
 3. Post the agent's response in the same thread
 
-You can continue the conversation by replying in the same thread — no need to `@mention` the bot again. To specify a different agent in the thread, use `@alice message`.
+You can continue the conversation by replying in the same thread — no need to `@mention` the bot again. To specify a different agent in the thread, use `@@alice message`.
 
 ## Troubleshooting
 

--- a/subsystems/slack-bot/src/index.ts
+++ b/subsystems/slack-bot/src/index.ts
@@ -156,13 +156,17 @@ function formatSystemMessage(content: string): string | null {
 let slackApp: InstanceType<typeof App>;
 
 async function pollLoop(): Promise<void> {
-  while (true) {
+  while (!shuttingDown) {
     try {
       const messages = await hubPoll();
       for (const msg of messages) {
         // Handle system notifications (user join/leave)
         if (msg.from === "system") {
           console.log(`[system] ${msg.content}`);
+          if (msg.content.startsWith("RADIO_KILLED:")) {
+            console.log("[slack-bot] Received RADIO_KILLED, stopping poll loop.");
+            return;
+          }
           if (slackNotifyChannel) {
             const text = formatSystemMessage(msg.content);
             if (text) {

--- a/subsystems/slack-bot/src/index.ts
+++ b/subsystems/slack-bot/src/index.ts
@@ -191,7 +191,7 @@ async function pollLoop(): Promise<void> {
           await slackApp.client.chat.postMessage({
             channel: pending.slackChannel,
             thread_ts: pending.threadTs,
-            text: `*${msg.from}*:\n${msg.content}`,
+            text: `*@@${msg.from}*:\n${msg.content}`,
           });
         } else {
           // No pending reply — post as a new message to a default channel if configured

--- a/subsystems/slack-bot/src/index.ts
+++ b/subsystems/slack-bot/src/index.ts
@@ -224,14 +224,14 @@ function stripBotMention(text: string): string {
 }
 
 // ---------------------------------------------------------------------------
-// Parse mention text: "@walkie-talkie @alice do something" or "@walkie-talkie do something"
+// Parse mention text: "@walkie-talkie @@alice do something" or "@walkie-talkie do something"
 // ---------------------------------------------------------------------------
 
 function parseCommand(text: string): { to: string; content: string } {
   const trimmed = text.trim();
 
-  // Check if the first word is @someone
-  const match = trimmed.match(/^@(\S+)\s+([\s\S]*)$/);
+  // Check if the first token is @@someone (double-@ to avoid Slack mention confusion)
+  const match = trimmed.match(/^@@(\S+)\s+([\s\S]*)$/);
   if (match) {
     return { to: `@${match[1]}`, content: match[2].trim() };
   }
@@ -257,7 +257,7 @@ async function main(): Promise<void> {
 
     if (!rawText) {
       await say({
-        text: "Usage: `@walkie-talkie @agent-name message` or `@walkie-talkie message`",
+        text: "Usage: `@walkie-talkie @@agent-name message` or `@walkie-talkie message`",
         thread_ts: event.ts,
       });
       return;


### PR DESCRIPTION
## Release v1.6.0

## v1.6.0 (2026-03-09)

### Features
- Add client role (agent/bridge) for relay services (#96)
- Add system notifications for bridge clients (#98)
- Add agent launcher with iTerm2 integration and dashboard UI (#109)
- Add launcher docs to README and handle missing iTerm2 gracefully (#115)

### Fixes
- Fix misleading trigger description in comparison table (#91)
- Use @@ prefix for agent targeting in Slack bot (#103)
- Show @@ prefix in agent reply display name (#105)
- Show user-friendly error when port is already in use (#110)
- Restore terminal to cooked mode on shutdown (#111)
- Remove Claude-specific hints from agent launcher (#113)

### Other
- Add Slack bot integration section to README (#85)
- Add Cursor Automations comparison to README (#87)
- Move slack-bot to subsystems/ and co-launch with npm start (#94)
- Document 'Always Show My Bot as Online' Slack setting (#100)