### PR TITLE
Release v1.7.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "walkie-talkie",
       "source": "./plugin",
       "description": "A lightweight communication layer for AI agents",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "author": {
         "name": "suruseas"
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## v1.7.0 (2026-03-09)
+
+### Features
+- Add client role (agent/bridge) for relay services (#96)
+- Add system notifications for bridge clients (#98)
+- Add agent launcher with iTerm2 integration and dashboard UI (#109)
+- Add launcher docs to README and handle missing iTerm2 gracefully (#115)
+
+### Fixes
+- Fix misleading trigger description in comparison table (#91)
+- Use @@ prefix for agent targeting in Slack bot (#103)
+- Show @@ prefix in agent reply display name (#105)
+- Show user-friendly error when port is already in use (#110)
+- Restore terminal to cooked mode on shutdown (#111)
+- Remove Claude-specific hints from agent launcher (#113)
+
+### Other
+- Add Slack bot integration section to README (#85)
+- Add Cursor Automations comparison to README (#87)
+- Move slack-bot to subsystems/ and co-launch with npm start (#94)
+- Document 'Always Show My Bot as Online' Slack setting (#100)
+
+
 ## v1.6.0 (2026-03-09)
 
 ### Features

--- a/hub/package.json
+++ b/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@walkie-talkie/hub",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@walkie-talkie/mcp-server",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "walkie-talkie",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "walkie-talkie",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "A lightweight communication layer for AI agents",
   "mcpServers": {
     "walkie-talkie": {


### PR DESCRIPTION
## Release v1.7.0

## v1.7.0 (2026-03-09)

### Features
- Add client role (agent/bridge) for relay services (#96)
- Add system notifications for bridge clients (#98)
- Add agent launcher with iTerm2 integration and dashboard UI (#109)
- Add launcher docs to README and handle missing iTerm2 gracefully (#115)

### Fixes
- Fix misleading trigger description in comparison table (#91)
- Use @@ prefix for agent targeting in Slack bot (#103)
- Show @@ prefix in agent reply display name (#105)
- Show user-friendly error when port is already in use (#110)
- Restore terminal to cooked mode on shutdown (#111)
- Remove Claude-specific hints from agent launcher (#113)

### Other
- Add Slack bot integration section to README (#85)
- Add Cursor Automations comparison to README (#87)
- Move slack-bot to subsystems/ and co-launch with npm start (#94)
- Document 'Always Show My Bot as Online' Slack setting (#100)