### PR TITLE
fix(mcp-server): correct radio_token script path and radio_channels user serialization

### DIFF
--- a/hub/src/types.ts
+++ b/hub/src/types.ts
@@ -58,7 +58,7 @@ export interface PollResponse {
 }
 
 export interface UsersResponse {
-  users: string[];
+  users: Array<{ name: string; online: boolean; role: string }>;
 }
 
 export interface ErrorResponse {

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -9,13 +9,15 @@
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf dist",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "test": "vitest run"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0"
   },
   "devDependencies": {
     "typescript": "^5.7.0",
-    "@types/node": "^22.0.0"
+    "@types/node": "^22.0.0",
+    "vitest": "^3.0.0"
   }
 }

--- a/mcp-server/src/__tests__/helpers.test.ts
+++ b/mcp-server/src/__tests__/helpers.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { formatConnectedUsers, resolveWaitScript } from "../helpers.js";
+
+describe("resolveWaitScript", () => {
+  // radio-wait.sh physically lives only at <repo>/plugin/bin/radio-wait.sh.
+  const REAL = "/repo/plugin/bin/radio-wait.sh";
+  const existsOnlyPluginBin = (p: string) => p === REAL;
+
+  it("resolves the real plugin/bin path when running from the mcp-server/dist build", () => {
+    // Regression: the old single-candidate `../bin` logic returned
+    // /repo/mcp-server/bin/radio-wait.sh here, which does not exist.
+    const result = resolveWaitScript("/repo/mcp-server/dist", existsOnlyPluginBin);
+    expect(result).toBe(REAL);
+    expect(result).not.toBe("/repo/mcp-server/bin/radio-wait.sh");
+  });
+
+  it("resolves the real plugin/bin path when running from the bundled plugin/dist entry", () => {
+    const result = resolveWaitScript("/repo/plugin/dist", existsOnlyPluginBin);
+    expect(result).toBe(REAL);
+  });
+
+  it("never returns a path the predicate rejects when a candidate exists", () => {
+    const result = resolveWaitScript("/repo/mcp-server/dist", existsOnlyPluginBin);
+    expect(existsOnlyPluginBin(result)).toBe(true);
+  });
+
+  it("falls back to the first candidate when no candidate exists on disk", () => {
+    const result = resolveWaitScript("/repo/mcp-server/dist", () => false);
+    expect(result).toBe("/repo/mcp-server/bin/radio-wait.sh");
+  });
+});
+
+describe("formatConnectedUsers", () => {
+  it("renders user names from the hub's object array", () => {
+    const out = formatConnectedUsers([
+      { name: "skills", online: true },
+      { name: "dora", online: true },
+    ]);
+    expect(out).toBe("Connected users: skills, dora");
+  });
+
+  it("never renders [object Object] for object input (regression)", () => {
+    const out = formatConnectedUsers([
+      { name: "skills", online: true },
+      { name: "dora", online: true },
+    ]);
+    expect(out).not.toContain("[object Object]");
+  });
+
+  it("marks offline users so stale registrations are visible", () => {
+    const out = formatConnectedUsers([
+      { name: "skills", online: true },
+      { name: "dora", online: false },
+    ]);
+    expect(out).toBe("Connected users: skills, dora (offline)");
+  });
+
+  it("reports the empty case", () => {
+    expect(formatConnectedUsers([])).toBe("No users connected.");
+  });
+});

--- a/mcp-server/src/client.ts
+++ b/mcp-server/src/client.ts
@@ -195,8 +195,12 @@ export class HubClient {
     return res.data;
   }
 
-  async users(token: string): Promise<string[]> {
-    const res = await this.request<{ users: string[] }>({
+  async users(token: string): Promise<Array<{ name: string; online: boolean; role: string }>> {
+    // The hub's GET /users returns objects ({ name, online, role }), not bare
+    // strings — see hub handleUsers + its api-register/api-admin tests. The
+    // prior `string[]` typing was wrong and caused callers to render
+    // "[object Object]" when joining the array.
+    const res = await this.request<{ users: Array<{ name: string; online: boolean; role: string }> }>({
       method: "GET",
       path: "/users",
       token,

--- a/mcp-server/src/helpers.ts
+++ b/mcp-server/src/helpers.ts
@@ -1,0 +1,39 @@
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Resolve the on-disk path to `radio-wait.sh`.
+ *
+ * The script ships only in `plugin/bin/`, but `radio_token` resolves it
+ * relative to the running module — whose location differs by entry point:
+ *   - bundled `plugin/dist/*.mjs` → `../bin/radio-wait.sh`
+ *   - built `mcp-server/dist/*`   → `../../plugin/bin/radio-wait.sh`
+ *
+ * Probing both candidates and returning the first that exists keeps
+ * `radio_token` honest regardless of which entry runs. Regression: the old
+ * single-candidate `../bin` logic returned a nonexistent `mcp-server/bin/`
+ * path when the server ran from the `mcp-server/dist` build.
+ *
+ * `exists` is injectable for testing; it defaults to `fs.existsSync`.
+ */
+export function resolveWaitScript(thisDir: string, exists: (p: string) => boolean = fs.existsSync): string {
+  const candidates = [
+    path.resolve(thisDir, "..", "bin", "radio-wait.sh"),
+    path.resolve(thisDir, "..", "..", "plugin", "bin", "radio-wait.sh"),
+  ];
+  return candidates.find(exists) ?? candidates[0];
+}
+
+/**
+ * Render the hub's connected-user list for `radio_channels`.
+ *
+ * The hub returns user OBJECTS (`{ name, online, role }`), so rendering must
+ * project to `name`. Regression: joining the raw objects printed
+ * "[object Object]". Offline users are marked because the hub already
+ * provides the flag and it helps spot stale registrations.
+ */
+export function formatConnectedUsers(users: Array<{ name: string; online: boolean }>): string {
+  if (users.length === 0) return "No users connected.";
+  const rendered = users.map((u) => (u.online ? u.name : `${u.name} (offline)`)).join(", ");
+  return `Connected users: ${rendered}`;
+}

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { HubClient } from "./client.js";
+import { formatConnectedUsers, resolveWaitScript } from "./helpers.js";
 
 const MIME_TYPES: Record<string, string> = {
   ".png": "image/png",
@@ -337,7 +338,7 @@ export function createMcpServer(hubUrl: string, joinTok: string): McpServer {
       }
       try {
         const [users, channels] = await Promise.all([client.users(currentToken), client.listChannels(currentToken)]);
-        const userText = users.length > 0 ? `Connected users: ${users.join(", ")}` : "No users connected.";
+        const userText = formatConnectedUsers(users);
         const channelText =
           channels.length > 0
             ? `Channels: ${channels.map((c) => `${c.name} (${c.memberCount} members)`).join(", ")}`
@@ -493,8 +494,7 @@ export function createMcpServer(hubUrl: string, joinTok: string): McpServer {
           isError: true,
         };
       }
-      const thisFile = fileURLToPath(import.meta.url);
-      const waitScript = path.resolve(path.dirname(thisFile), "..", "bin", "radio-wait.sh");
+      const waitScript = resolveWaitScript(path.dirname(fileURLToPath(import.meta.url)));
       return {
         content: [
           {

--- a/mcp-server/vitest.config.ts
+++ b/mcp-server/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    pool: "forks",
+    fileParallelism: false,
+    include: ["src/__tests__/**/*.test.ts"],
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "walkie-talkie",
-  "version": "1.5.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "walkie-talkie",
-      "version": "1.5.0",
+      "version": "1.7.0",
       "workspaces": [
         "hub",
         "mcp-server",
@@ -19,7 +19,7 @@
     },
     "hub": {
       "name": "@walkie-talkie/hub",
-      "version": "1.5.0",
+      "version": "1.7.0",
       "dependencies": {
         "better-sqlite3": "^12.6.2"
       },
@@ -32,7 +32,7 @@
     },
     "mcp-server": {
       "name": "@walkie-talkie/mcp-server",
-      "version": "1.5.0",
+      "version": "1.7.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0"
       },
@@ -41,7 +41,8 @@
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
-        "typescript": "^5.7.0"
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
       }
     },
     "node_modules/@biomejs/biome": {


### PR DESCRIPTION
# fix(mcp-server): correct radio_token script path and radio_channels user serialization

## Summary

Two small fixes in the `mcp-server` package, plus one stale type in `hub`. I ran into both while running the server from the manual install and using the radio tools.

## Bug 1: radio_token returns a path that does not exist

`radio_token` computes the script path as `<thisFile>/../bin/radio-wait.sh`. That resolves correctly only when the server runs from the bundled `plugin/dist/` entry, where it lands on `plugin/bin/`. When the server runs from the `mcp-server/dist/` build it resolves to `mcp-server/bin/`, which does not exist, so anything that uses the returned path fails with "No such file or directory".

The README documents running the server that way. Its manual install is:

```bash
claude mcp add walkie-talkie \
  -- node /absolute/path/to/walkie-talkie/mcp-server/dist/index.js
```

`mcp-server/package.json` also declares `dist/index.js` as both its `bin` and its `start` target. The plugin and marketplace install runs the bundled `plugin/dist/mcp-server.mjs`, which resolves correctly, so the broken path only shows up on the manual install.

Fix: check both candidate locations and return the first that exists.

```ts
const thisDir = path.dirname(fileURLToPath(import.meta.url));
const candidates = [
  path.resolve(thisDir, "..", "bin", "radio-wait.sh"),                 // bundled plugin/dist
  path.resolve(thisDir, "..", "..", "plugin", "bin", "radio-wait.sh"), // mcp-server/dist
];
const waitScript = candidates.find((p) => fs.existsSync(p)) ?? candidates[0];
```

## Bug 2: radio_channels renders connected users as [object Object]

`GET /users` on the hub returns user objects of the form `{ name, online, role }`. The `mcp-server` `HubClient.users()` types the response as `string[]`, and `radio_channels` joins the array directly, so the output is `Connected users: [object Object], [object Object]`.

This is drift. At the first commit ([`7ecd8b4`](https://github.com/suruseas/walkie-talkie/commit/7ecd8b42b852bfe543506a3849adac276f72323a)), [`/users` returned an array of strings](https://github.com/suruseas/walkie-talkie/blob/7ecd8b42b852bfe543506a3849adac276f72323a/hub/src/server.ts#L72-L73) and `string[]` was correct. [`d62431a`](https://github.com/suruseas/walkie-talkie/commit/d62431a27163450247a0f8f67c17658bc0d0ed57) ("Show offline status for disconnected agents on dashboard") [changed the handler to return an array of objects](https://github.com/suruseas/walkie-talkie/blob/d62431a27163450247a0f8f67c17658bc0d0ed57/hub/src/server.ts#L107-L112), and they now also carry `online` and `role`, but the client type was never updated. The hub's `api-register` and `api-admin` tests read `users[].name`, and the dashboard reads `users[].name` and `users[].online`, so three call sites already depend on the object shape.

Fix:
- Type `HubClient.users()` to the object shape the hub returns.
- Render `u.name` in `radio_channels`, and add an `(offline)` marker when `u.online` is false. The flag is already in the response and it helps spot stale registrations.
- Update the unused `UsersResponse` type in `hub/src/types.ts` to match.

## Tests

`mcp-server` had no tests, which is why both bugs went unnoticed even though the hub side already covers the `/users` shape. This adds a vitest setup for `mcp-server` using the same config as `hub`, plus regression tests. The two fixes are factored into small pure functions, `resolveWaitScript()` and `formatConnectedUsers()` in `mcp-server/src/helpers.ts`, and `tools.ts` calls them.

- `resolveWaitScript`: from a `mcp-server/dist`-shaped directory where the script exists only in `plugin/bin/`, resolution returns the real path rather than the `mcp-server/bin/` path. Also covers the `plugin/dist` layout and the no-candidate fallback.
- `formatConnectedUsers`: renders names from the object array, never `[object Object]`, marks offline users, and handles the empty list.

Against the original inline code, 5 of the 8 assertions fail. Against the fix, all 8 pass.

## Verification

- `tsc` builds clean for `mcp-server` and `hub`.
- `mcp-server` tests: 8 passed (new). `hub` tests: 104 passed.
- `biome check` clean on the changed files.

## Files

`mcp-server/src/tools.ts`, `mcp-server/src/client.ts`, `mcp-server/src/helpers.ts`, `mcp-server/src/__tests__/helpers.test.ts`, `mcp-server/package.json`, `mcp-server/vitest.config.ts`, `hub/src/types.ts`.
